### PR TITLE
Grant radar workflow write access and add .gitignore

### DIFF
--- a/.github/workflows/radar.yml
+++ b/.github/workflows/radar.yml
@@ -15,6 +15,9 @@ on:
         type: choice
         options: ["false", "true"]
 
+permissions:
+  contents: write
+
 jobs:
   scrape:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+briefing_*.md
+events_raw.json


### PR DESCRIPTION
### Motivation
- Allow the scheduled `Basel Radar` workflow to create or update repository contents and prevent committing common generated and secret files.

### Description
- Add `permissions.contents: write` to `.github/workflows/radar.yml` so the workflow can push or create artifacts when needed.
- Add a `.gitignore` file ignoring `__pycache__/`, `*.pyc`, `.env`, `briefing_*.md`, and `events_raw.json` to keep generated and sensitive files out of the repo.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65089c8a0832dba40281c20cd9000)