### PR TITLE
🔒 [security fix] replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/scraper/gemini_day_scan.py
+++ b/scraper/gemini_day_scan.py
@@ -4,7 +4,7 @@ import json
 import time
 import random
 import hashlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Dict, Any, Tuple
 from urllib.parse import urljoin
 
@@ -533,7 +533,7 @@ def main() -> None:
         "raw_event_count": len(raw_json),
         "merged_event_count": len(final_merged),
         "scan_reports_count": len(scan_reports),
-        "generated_at_utc": datetime.utcnow().isoformat() + "Z",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
 
     write_json(os.path.join(DEBUG_DIR, "raw_extraction.json"), raw_json)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of the deprecated `datetime.utcnow()` method.
⚠️ **Risk:** While not a direct security exploit in this specific context, using deprecated methods can lead to runtime errors in future Python versions and often indicates a lack of proper timezone awareness, which can cause subtle bugs in data processing.
🛡️ **Solution:** Updated the code to use `datetime.now(timezone.utc)` and added the necessary `timezone` import. The output format was preserved using `.isoformat().replace("+00:00", "Z")`.

---
*PR created automatically by Jules for task [9945840135833387937](https://jules.google.com/task/9945840135833387937) started by @bummdidumm*