### PR TITLE
Harden release_audit file scanning and I/O handling

### DIFF
--- a/bummdidumm_os_v5_final_release/release_audit.py
+++ b/bummdidumm_os_v5_final_release/release_audit.py
@@ -1,16 +1,24 @@
 import json
-import os
 from pathlib import Path
 
 ROOT = Path("bummdidumm_os_v5_final_release")
 
+_PLACEHOLDER_TOKENS = [
+    "DEIN_PROJEKT_ID",
+    "DEINE_SHEET_ID",
+    "DEIN_API_KEY",
+    "DEIN_TARGET_FOLDER_ID",
+]
+
+_AUDIT_OUTPUT_FILES = {"release_audit.py", "SELF_AUDIT.md", "release_audit.json"}
+
 
 def _read(path: Path) -> str:
-    if not path.exists() or not path.is_file():
+    if not path.is_file():
         return ""
     try:
         return path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
+    except (OSError, UnicodeDecodeError):
         return ""
 
 
@@ -21,17 +29,17 @@ def run_audit() -> bool:
         errors.append("Release root fehlt: bummdidumm_os_v5_final_release")
 
     for p in ROOT.rglob("*"):
-        if p.name == "__pycache__":
+        if "__pycache__" in p.parts:
             errors.append(f"__pycache__ gefunden: {p}")
         if p.suffix == ".pyc":
             errors.append(f".pyc gefunden: {p}")
 
-    tokens = ["DEIN"+"_PROJEKT_ID", "DEINE"+"_SHEET_ID", "DEIN"+"_API_KEY", "DEIN"+"_TARGET_FOLDER_ID"]
-    for bad in tokens:
-        for p in ROOT.rglob("*"):
-            if "__pycache__" in p.parts or p.suffix == ".pyc":
-                continue
-            if p.is_file() and p.name not in {"release_audit.py", "SELF_AUDIT.md", "release_audit.json"} and bad in _read(p):
+        if not p.is_file() or p.name in _AUDIT_OUTPUT_FILES:
+            continue
+
+        text = _read(p)
+        for bad in _PLACEHOLDER_TOKENS:
+            if bad in text:
                 errors.append(f"Platzhalter {bad} gefunden in {p}")
 
     code = _read(ROOT / "appsscript" / "Code.gs")
@@ -79,7 +87,7 @@ def run_audit() -> bool:
             errors.append(f"Gemini Robustness fehlt: {must}")
 
     summary = {"result": "PASS" if not errors else "FAIL", "errors": errors}
-    (ROOT / "release_audit.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    (ROOT / "release_audit.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
     (ROOT / "SELF_AUDIT.md").write_text("# Self Audit\n\n" + ("PASS ✅" if not errors else "FAIL ❌") + "\n" + "\n".join(f"- {e}" for e in errors), encoding="utf-8")
 
     if errors:


### PR DESCRIPTION
### Motivation
- Improve robustness and performance of the release audit by avoiding repeated file traversals and by making file reads and placeholder detection more reliable.
- Ensure the audit reliably detects unwanted artifacts like `__pycache__` and `.pyc` files and preserves non-ASCII error messages in output.

### Description
- Consolidated placeholder scanning into a single `ROOT.rglob("*")` traversal so each file is read once and all `_PLACEHOLDER_TOKENS` are checked per-file.
- Added `_PLACEHOLDER_TOKENS` and `_AUDIT_OUTPUT_FILES` constants and replaced runtime string concatenation with literal tokens to avoid accidental mismatches.
- Unified `__pycache__` detection with the traversal using the guard `"__pycache__" in p.parts`, and retained `.pyc` checks in the same loop.
- Hardened `_read()` to use `path.is_file()` only and catch `(OSError, UnicodeDecodeError)`, removed the unused `os` import, and write JSON with `ensure_ascii=False` to preserve non-ASCII messages.

### Testing
- Ran `python -m py_compile bummdidumm_os_v5_final_release/release_audit.py` which succeeded.
- Executed `python bummdidumm_os_v5_final_release/release_audit.py` during validation and it reported `__pycache__`/`.pyc` findings as expected, demonstrating the new detection logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce242c50a8832dbf2069e388474ed4)