### PR TITLE
🧪 [testing] add unit tests for check_md5_size_prefilter

### DIFF
--- a/bummdidumm_os_v5_final_release/tests/smoke/test_change_type_logic.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_change_type_logic.py
@@ -1,0 +1,102 @@
+import unittest
+from shared.change_type_logic import check_md5_size_prefilter
+
+class TestChangeTypeLogic(unittest.TestCase):
+
+    def test_prefilter_not_in_known_details(self):
+        f = {"id": "new-file"}
+        known = {}
+        self.assertFalse(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_google_apps_mime(self):
+        f = {
+            "id": "doc-1",
+            "mimeType": "application/vnd.google-apps.document",
+            "md5Checksum": "hash1",
+            "size": "100"
+        }
+        known = {
+            "doc-1": {"md5": "hash1", "size_bytes": "100"}
+        }
+        # Native formats should return False (no MD5 available for them normally)
+        self.assertFalse(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_exact_match(self):
+        f = {
+            "id": "file-1",
+            "md5Checksum": "hash1",
+            "size": "100"
+        }
+        known = {
+            "file-1": {"md5": "hash1", "size_bytes": "100"}
+        }
+        self.assertTrue(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_md5_mismatch(self):
+        f = {
+            "id": "file-1",
+            "md5Checksum": "hash-new",
+            "size": "100"
+        }
+        known = {
+            "file-1": {"md5": "hash-old", "size_bytes": "100"}
+        }
+        self.assertFalse(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_size_mismatch(self):
+        f = {
+            "id": "file-1",
+            "md5Checksum": "hash1",
+            "size": "200"
+        }
+        known = {
+            "file-1": {"md5": "hash1", "size_bytes": "100"}
+        }
+        self.assertFalse(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_missing_current_md5(self):
+        f = {
+            "id": "file-1",
+            "size": "100"
+            # md5Checksum missing
+        }
+        known = {
+            "file-1": {"md5": "hash1", "size_bytes": "100"}
+        }
+        self.assertFalse(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_missing_cached_md5(self):
+        f = {
+            "id": "file-1",
+            "md5Checksum": "hash1",
+            "size": "100"
+        }
+        known = {
+            "file-1": {"size_bytes": "100"}
+            # md5 missing
+        }
+        self.assertFalse(check_md5_size_prefilter(f, known))
+
+    def test_prefilter_size_string_int_flexibility(self):
+        f = {
+            "id": "file-1",
+            "md5Checksum": "hash1",
+            "size": 100 # int
+        }
+        known = {
+            "file-1": {"md5": "hash1", "size_bytes": "100"} # str
+        }
+        self.assertTrue(check_md5_size_prefilter(f, known))
+
+        f2 = {
+            "id": "file-2",
+            "md5Checksum": "hash2",
+            "size": "500" # str
+        }
+        known2 = {
+            "file-2": {"md5": "hash2", "size_bytes": 500} # int
+        }
+        self.assertTrue(check_md5_size_prefilter(f2, known2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `check_md5_size_prefilter` function in `bummdidumm_os_v5_final_release/shared/change_type_logic.py` was previously untested. This PR adds a dedicated test suite to ensure its reliability.

### 📊 Coverage: What scenarios are now tested
- **Cache Miss:** Returns `False` if the file is not in known details.
- **Native Formats:** Returns `False` for `application/vnd.google-apps` MIME types.
- **Happy Path:** Returns `True` when both MD5 and size match exactly.
- **Mismatches:** Returns `False` if either MD5 or size differ.
- **Missing Data:** Returns `False` if MD5 is missing from either the current file metadata or the cache.
- **Data Type Resilience:** Verifies that the function correctly handles size as either a string or an integer.

### ✨ Result: The improvement in test coverage
Increased test coverage for critical change detection logic, ensuring that the pre-filtering of unchanged files is accurate and robust against various metadata states.

---
*PR created automatically by Jules for task [4118661092134652005](https://jules.google.com/task/4118661092134652005) started by @bummdidumm*