### PR TITLE
Fix temp path leak in title

### DIFF
--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -87,11 +87,8 @@ def _build_personal_brain_sources(records_to_index, drive_service, enable_shared
                 mime=mime,
                 ext=ext,
                 fallback_text=rec.ocr_full_text or rec.ocr_summary or rec.notes or "",
+                original_path=rec.path_display or rec.name
             )
-
-            # Fix leak of temp path in title
-            if local_path and detected.get("content", {}).get("title") == os.path.basename(local_path):
-                detected["content"]["title"] = rec.name
 
             # Recursive dispatch: if the detected content found parseable files inside a ZIP
             if detected.get("is_archive") and "archive_files" in detected.get("content", {}) and local_path:
@@ -115,11 +112,10 @@ def _build_personal_brain_sources(records_to_index, drive_service, enable_shared
                                     source_path=sub_local_path,
                                     mime=sub_mime,
                                     ext=sub_ext,
-                                    fallback_text=""
+                                    fallback_text="",
+                                    original_path=zinfo.filename
                                 )
                                 sub_content = sub_detected.get("content", {})
-                                if sub_content.get("title") == os.path.basename(sub_local_path):
-                                    sub_content["title"] = zinfo.filename
                                 sub_content.setdefault("title", zinfo.filename)
                                 sub_event_time = rec.ocr_date or rec.run_utc or ""
                                 sub_content.setdefault("event_time_start", sub_event_time)

--- a/bummdidumm_os_v5_final_release/personal_brain/source_ingestion.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/source_ingestion.py
@@ -13,13 +13,23 @@ def _detect_bundle(path: str, ext: str) -> tuple[bool, bool]:
     return is_bundle, is_archive
 
 
-def inspect_source(source_path: str, mime: str, ext: str, fallback_text: str = "") -> dict[str, Any]:
+def inspect_source(
+    source_path: str,
+    mime: str,
+    ext: str,
+    fallback_text: str = "",
+    original_path: str | None = None
+) -> dict[str, Any]:
     path_obj = Path(source_path)
+    # Use original_path for semantic detection (title, is_export) if provided,
+    # otherwise fallback to the actual local source_path.
+    detection_path = original_path or source_path
+
     preview: dict[str, Any] = {}
     text_preview = fallback_text or ""
     content: dict[str, Any] = {"raw_text": fallback_text}
 
-    is_bundle, is_archive = _detect_bundle(source_path, ext)
+    is_bundle, is_archive = _detect_bundle(detection_path, ext)
 
     if path_obj.exists() and path_obj.is_file():
         try:
@@ -46,7 +56,7 @@ def inspect_source(source_path: str, mime: str, ext: str, fallback_text: str = "
                             text = f.read(8000).decode("utf-8", errors="ignore")
                             text_preview = text[:1000]
                             content["raw_text"] = text
-                            content["title"] = path_obj.name
+                            content["title"] = Path(detection_path).name
                             content["summary"] = f"Archive containing {len(namelist)} files."
 
             elif ext == ".json":
@@ -57,7 +67,7 @@ def inspect_source(source_path: str, mime: str, ext: str, fallback_text: str = "
             elif ext in {".html", ".htm", ".txt", ".md", ".ics", ".csv"}:
                 text = path_obj.read_text(encoding="utf-8", errors="ignore")[:8000]
                 text_preview = text[:1000]
-                content = {"raw_text": text, "title": path_obj.name, "summary": text[:200]}
+                content = {"raw_text": text, "title": Path(detection_path).name, "summary": text[:200]}
         except Exception:
             pass
     return {
@@ -66,5 +76,5 @@ def inspect_source(source_path: str, mime: str, ext: str, fallback_text: str = "
         "content": content,
         "is_bundle": is_bundle,
         "is_archive": is_archive,
-        "is_export": ("export" in source_path.lower()) or is_bundle,
+        "is_export": ("export" in detection_path.lower()) or is_bundle,
     }

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tempfile
 import unittest
@@ -241,6 +242,32 @@ class PersonalBrainSmokeTest(unittest.TestCase):
         # Content must have the full structure, not just {"raw_text": ...}
         self.assertIn("conversations", detected["content"])
         self.assertIsInstance(detected["content"]["conversations"], list)
+
+    def test_inspect_source_uses_original_path_for_title_and_export(self):
+        """Passing original_path to inspect_source should fix temp path leaks in title and is_export."""
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tf:
+            tf.write(b"content")
+            temp_path = tf.name
+
+        try:
+            # Case 1: No original_path -> leaks temp name
+            detected_leaked = inspect_source(temp_path, mime="text/plain", ext=".txt")
+            self.assertEqual(detected_leaked["content"]["title"], Path(temp_path).name)
+            self.assertFalse(detected_leaked["is_export"])
+
+            # Case 2: With original_path -> uses it for title and export detection
+            orig_name = "my_custom_export.txt"
+            detected_fixed = inspect_source(
+                temp_path,
+                mime="text/plain",
+                ext=".txt",
+                original_path=orig_name
+            )
+            self.assertEqual(detected_fixed["content"]["title"], orig_name)
+            self.assertTrue(detected_fixed["is_export"], "Should detect 'export' in original_path")
+        finally:
+            if Path(temp_path).exists():
+                os.remove(temp_path)
 
     # ------------------------------------------------------------------
     # P2: New LLM parser tests


### PR DESCRIPTION
The temporary path of a downloaded file can leak into the title of the detected content. The fix is to provide the original filename to the inspection function and use it for metadata generation.

Changes:
1.  Modified `bummdidumm_os_v5_final_release/personal_brain/source_ingestion.py`:
    *   Added `original_path` parameter to `inspect_source`.
    *   Updated `_detect_bundle` and `is_export` logic to use `original_path` if provided.
    *   Updated `content["title"]` fallback to use `original_path` if provided.
2.  Modified `bummdidumm_os_v5_final_release/main_pass2.py`:
    *   Updated `inspect_source` calls to pass the canonical name/path.
    *   Cleaned up manual fix-up logic that was checking for temp path leaks.
3.  Modified `bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py`:
    *   Added `test_inspect_source_uses_original_path_for_title_and_export` to verify the fix.
    *   Added missing `import os`.

---
*PR created automatically by Jules for task [17047333623085869145](https://jules.google.com/task/17047333623085869145) started by @bummdidumm*