### PR TITLE
Follow-up: fix archive MIME classification and preserve entity source counts

### DIFF
--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -103,7 +103,15 @@ def _build_personal_brain_sources(records_to_index, drive_service, enable_shared
                             continue
                         sub_ext = os.path.splitext(zinfo.filename)[1].lower()
                         if sub_ext in _PARSEABLE_EXTS:
-                            sub_mime = "application/json" if sub_ext == ".json" else "text/plain" if sub_ext == ".txt" else "text/html" if sub_ext in [".html", ".htm"] else "text/csv" if sub_ext == ".csv" else ""
+                            sub_mime = (
+                                "application/json" if sub_ext == ".json" else
+                                "text/plain" if sub_ext == ".txt" else
+                                "text/html" if sub_ext in [".html", ".htm"] else
+                                "text/csv" if sub_ext == ".csv" else
+                                "text/markdown" if sub_ext == ".md" else
+                                "text/calendar" if sub_ext == ".ics" else
+                                ""
+                            )
                             sub_local_path = None
                             try:
                                 with tempfile.NamedTemporaryFile(delete=False, suffix=sub_ext) as tf:

--- a/bummdidumm_os_v5_final_release/personal_brain/writers.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/writers.py
@@ -154,7 +154,11 @@ class JsonlWriter:
         tmp_entity_path = entity_path.with_suffix(".tmp")
         with tmp_entity_path.open("w", encoding="utf-8") as f:
             for k in sorted(merged_entities):
-                clean = {ek: ev for ek, ev in merged_entities[k].items() if not ek.startswith("_")}
+                clean = {
+                    ek: ev
+                    for ek, ev in merged_entities[k].items()
+                    if not ek.startswith("_") or ek == "_counts_by_source"
+                }
                 f.write(json.dumps(clean, ensure_ascii=False) + "\n")
         tmp_entity_path.replace(entity_path)
 


### PR DESCRIPTION
### Motivation
- Address medium-priority review feedback to ensure archive sub-files get correct text MIME types and to retain per-source entity counts across incremental runs.

### Description
- Added explicit MIME mappings for `.md` and `.ics` when extracting ZIP entries in `bummdidumm_os_v5_final_release/main_pass2.py`, and updated `bummdidumm_os_v5_final_release/personal_brain/writers.py` to preserve the `_counts_by_source` metadata while still filtering other internal underscore-prefixed keys.

### Testing
- Verified syntax by running `python -m py_compile bummdidumm_os_v5_final_release/main_pass2.py bummdidumm_os_v5_final_release/personal_brain/writers.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3af6cc978832daffb69788bfde0df)