### PR TITLE
fix(pass2): prevent IndexError on short sorting rows

### DIFF
--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -242,7 +242,8 @@ def run_pass2():
     sorting_data = {}
     for sort_chunk in sheet_mgr.read_rows_chunked("Sorting_Suggestions", chunk_size=2000):
         for s_row in sort_chunk:
-            if len(s_row) >= 12 and s_row[0] == current_run_id:
+            # We access index 12 (move_result) below, so we need at least 13 columns to avoid an IndexError.
+            if len(s_row) >= 13 and s_row[0] == current_run_id:
                 sorting_data[s_row[1]] = {
                     "current_parent_id": s_row[5],
                     "folder_rule": s_row[6],


### PR DESCRIPTION
In `bummdidumm_os_v5_final_release/main_pass2.py`, there was an off-by-one boundary check logic that accessed `s_row[12]` when `len(s_row) >= 12`. This caused an `IndexError` for rows with exactly 12 elements.

This PR addresses the issue by shifting the bounds check to `len(s_row) >= 13`. An inline comment was added to make the rationale clear. Tests were run to ensure that the change correctly ignores short rows without errors while preserving valid parsing logic.

---
*PR created automatically by Jules for task [1653708390743164672](https://jules.google.com/task/1653708390743164672) started by @bummdidumm*