### PR TITLE
🎨 Palette: Replace alert with non-blocking toast for success states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Use non-blocking notifications for script success states
+**Learning:** Google Apps Script success states (`startFullRun`, `startFastDeltaScan`, etc.) used blocking `alert()` popups which interrupt user workflow, whereas non-blocking `toast()` notifications provide a smoother, less intrusive UX for positive feedback, especially for asynchronous trigger jobs.
+**Action:** When updating Apps Script UIs with multiple entry points (menu actions), abstract repetitive result handling into a centralized helper function (`handleTriggerResult`) that uses `toast()` for success and `alert()` for errors.

--- a/bummdidumm_os_v5_final_release/appsscript/Code.gs
+++ b/bummdidumm_os_v5_final_release/appsscript/Code.gs
@@ -147,11 +147,19 @@ function autoCleanupTransientFolder() {
   }
 }
 
-function startFastDeltaScan() { SpreadsheetApp.getUi().alert(triggerJob("bummdidumm-pass1-delta-dedupe").msg); }
-function startOcrIndexing() { SpreadsheetApp.getUi().alert(triggerJob("bummdidumm-pass2-ocr-index").msg); }
-function startApplyRenames() { SpreadsheetApp.getUi().alert(triggerJob("bummdidumm-apply-renames").msg); }
-function startSafeSort() { SpreadsheetApp.getUi().alert(triggerJob("bummdidumm-safe-sort").msg); }
-function startApplySort() { SpreadsheetApp.getUi().alert(triggerJob("bummdidumm-apply-sort").msg); }
+function handleTriggerResult(res) {
+  if (res.success) {
+    SpreadsheetApp.getActiveSpreadsheet().toast(res.msg, "Erfolg", 5);
+  } else {
+    SpreadsheetApp.getUi().alert(res.msg);
+  }
+}
+
+function startFastDeltaScan() { handleTriggerResult(triggerJob("bummdidumm-pass1-delta-dedupe")); }
+function startOcrIndexing() { handleTriggerResult(triggerJob("bummdidumm-pass2-ocr-index")); }
+function startApplyRenames() { handleTriggerResult(triggerJob("bummdidumm-apply-renames")); }
+function startSafeSort() { handleTriggerResult(triggerJob("bummdidumm-safe-sort")); }
+function startApplySort() { handleTriggerResult(triggerJob("bummdidumm-apply-sort")); }
 
 function startFullRun() {
   const res = triggerJob("bummdidumm-pass1-delta-dedupe");
@@ -163,7 +171,7 @@ function startFullRun() {
   props.setProperty("FULL_RUN_RUN_ID", "run_" + new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14));
   props.setProperty("FULL_RUN_PHASE", "WAITING_FOR_PASS1");
   ensurePollingTrigger();
-  SpreadsheetApp.getUi().alert("✅ Kompletter Lauf gestartet.");
+  SpreadsheetApp.getActiveSpreadsheet().toast("✅ Kompletter Lauf gestartet.", "Erfolg", 5);
 }
 
 function clearErrorReports() {


### PR DESCRIPTION
🎨 Palette: Replace alert with non-blocking toast for success states

**💡 What:** Replaced the intrusive `alert()` UI popups with smooth, non-blocking `toast()` notifications for all successful background job triggers in the Google Apps Script control plane (`Code.gs`). Abstracted repetitive trigger logic into a clean `handleTriggerResult` helper. Created `.Jules/palette.md` to document critical UX learnings.
**🎯 Why:** Triggering long-running Cloud Run jobs via `alert()` creates an annoying blocking modal that requires the user to click "OK" just to dismiss a success message, interrupting their workflow. `toast()` notifications elegantly slide in at the bottom right and disappear automatically, providing essential feedback without stealing focus.
**♿ Accessibility:** `toast()` is significantly less jarring and cognitively demanding for users than an unexpected, blocking modal dialog.

Fixes UX inconsistencies in Apps Script control plane. All pre-commit formatting and syntax tests passed.

---
*PR created automatically by Jules for task [8557318073431991554](https://jules.google.com/task/8557318073431991554) started by @bummdidumm*