### PR TITLE
🎨 Palette: Add confirmation dialogs for destructive actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ debug_gemini_day_scan/
 *.log
 .DS_Store
 *.zip
+node_modules/

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-13 - Add confirmation dialogs for destructive AppScript actions
+**Learning:** AppScript custom menus directly triggering destructive actions (like `startApplySort` moving/deleting files) without any confirmation can lead to accidental operations. Users expect an intentional speed bump before modifying Drive structure or deleting logs. The built-in `SpreadsheetApp.getUi().alert()` provides a native, accessible way to intercept these clicks.
+**Action:** Always add YES/NO confirmations via `SpreadsheetApp.getUi().alert()` before executing destructive Google Workspace actions, and pair them with non-blocking `toast` success notifications.

--- a/bummdidumm_os_v5_final_release/appsscript/Code.gs
+++ b/bummdidumm_os_v5_final_release/appsscript/Code.gs
@@ -160,9 +160,24 @@ function handleJobAlert(jobName) {
 
 function startFastDeltaScan() { handleJobAlert("bummdidumm-pass1-delta-dedupe"); }
 function startOcrIndexing() { handleJobAlert("bummdidumm-pass2-ocr-index"); }
-function startApplyRenames() { handleJobAlert("bummdidumm-apply-renames"); }
+
+function startApplyRenames() {
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.alert('Bestätigung', 'Bist du sicher, dass du die Renames anwenden willst? (Destruktiv)', ui.ButtonSet.YES_NO);
+  if (response === ui.Button.YES) {
+    handleJobAlert("bummdidumm-apply-renames");
+  }
+}
+
 function startSafeSort() { handleJobAlert("bummdidumm-safe-sort"); }
-function startApplySort() { handleJobAlert("bummdidumm-apply-sort"); }
+
+function startApplySort() {
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.alert('Bestätigung', 'Bist du sicher, dass du die Sortierung anwenden willst? (Destruktiv)', ui.ButtonSet.YES_NO);
+  if (response === ui.Button.YES) {
+    handleJobAlert("bummdidumm-apply-sort");
+  }
+}
 
 function startFullRun() {
   const res = triggerJob("bummdidumm-pass1-delta-dedupe");
@@ -178,9 +193,14 @@ function startFullRun() {
 }
 
 function clearErrorReports() {
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Error_Report");
-  if (!sheet || sheet.getLastRow() <= 1) return;
-  sheet.getRange(2, 1, sheet.getLastRow() - 1, sheet.getLastColumn()).clearContent();
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.alert('Bestätigung', 'Bist du sicher, dass du die Error Reports leeren willst? (Destruktiv)', ui.ButtonSet.YES_NO);
+  if (response === ui.Button.YES) {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Error_Report");
+    if (!sheet || sheet.getLastRow() <= 1) return;
+    sheet.getRange(2, 1, sheet.getLastRow() - 1, sheet.getLastColumn()).clearContent();
+    SpreadsheetApp.getActiveSpreadsheet().toast("✅ Error Reports geleert.", "bummdidumm", 5);
+  }
 }
 
 function onOpen() {


### PR DESCRIPTION
## 💡 What: 
Added native UI confirmation dialogs before executing destructive Google Workspace actions triggered by Apps Script custom menus.

## 🎯 Why: 
Users expect an intentional speed bump before modifying Drive structure, bulk moving/renaming files, or permanently deleting logs. Previously, clicking these menu items would blindly trigger the jobs.

## ♿ Accessibility/UX: 
Prevents accidental clicks and provides clear, localized feedback on the action about to happen.

Also created the `palette.md` journal file and updated `.gitignore` for node modules.

---
*PR created automatically by Jules for task [15142428683841575591](https://jules.google.com/task/15142428683841575591) started by @bummdidumm*