### PR TITLE
hardening: final deploy/runtime/CI/compaction/audit pass

### DIFF
--- a/.github/workflows/personal-brain-gates.yml
+++ b/.github/workflows/personal-brain-gates.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip pytest pip-audit
-      - run: pip install -r bummdidumm_os_v5_final_release/requirements.txt
+      - run: pip install --no-deps -r bummdidumm_os_v5_final_release/requirements.lock
       - name: Security audit
-        run: pip-audit -r bummdidumm_os_v5_final_release/requirements.txt --skip-editable
+        run: pip-audit -r bummdidumm_os_v5_final_release/requirements.lock --skip-editable
       - run: python3 bummdidumm_os_v5_final_release/release_audit.py
       - run: PYTHONPATH=bummdidumm_os_v5_final_release pytest bummdidumm_os_v5_final_release/tests/ -q
 

--- a/README.md
+++ b/README.md
@@ -61,3 +61,29 @@ PYTHONPATH=bummdidumm_os_v5_final_release pytest bummdidumm_os_v5_final_release/
 Repository governance and finalization protocols are strictly defined to maintain consistency.
 - Read [REPO_GOVERNANCE_SETUP.md](REPO_GOVERNANCE_SETUP.md) for GitHub branch protection and review requirements.
 - Read [AGENT_FINALIZATION_PROTOCOL.md](AGENT_FINALIZATION_PROTOCOL.md) for automated agent task constraints.
+
+## Cloud Run Environment Variables
+
+The following environment variables **must** be set before running `deploy.sh`. Missing required variables cause the script to abort immediately (`set -euo pipefail`).
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PROJECT_ID` | Yes | GCP project ID |
+| `ARCHIVE_FOLDER_ID` | Yes | Google Drive folder ID for archived duplicates |
+| `INDEX_FOLDER_ID` | Yes | Google Drive folder ID for index outputs |
+| `CONTROL_SHEET_ID` | Yes | Google Sheets spreadsheet ID for state and reports |
+| `GEMINI_API_KEY` | Yes | Gemini API key for OCR / Personal Brain |
+| `SA_EMAIL` | Yes | Service account email for Cloud Run jobs |
+| `BRAIN_INDEX_ROOT` | Yes (Pass 2 + Safe Sort) | Persistent path for the Personal Brain index |
+| `TARGET_FOLDER_ID` | No | Optional Drive folder to scope Pass 1 scanning |
+| `REGION` | No | Cloud Run region (default: `europe-west6`) |
+| `SKIP_OVER_MB` | No | Skip files larger than this MB (default: 500) |
+| `OCR_BUDGET_PER_RUN` | No | Max OCR calls per Pass 2 run (default: 500) |
+
+### BRAIN_INDEX_ROOT
+
+- **Mandatory for Pass 2 and Safe Sort in Cloud Run.**
+- Must point to a persistent path — a mounted volume, a Cloud Storage FUSE mount, or a deliberately managed directory.
+- `main_pass2.py` raises `RuntimeError` at startup if `BRAIN_INDEX_ROOT` is not set when `K_SERVICE` is detected (i.e. running in Cloud Run).
+- Without a persistent mount, the brain index is lost on container restart.
+- Example: a Cloud Storage FUSE-mounted path like `/mnt/brain_index`.

--- a/bummdidumm_os_v5_final_release/.dockerignore
+++ b/bummdidumm_os_v5_final_release/.dockerignore
@@ -1,0 +1,10 @@
+tests/
+*.md
+release_audit.json
+SELF_AUDIT.md
+Dockerfile.*
+*.sh
+__pycache__/
+*.pyc
+.env
+appsscript/

--- a/bummdidumm_os_v5_final_release/Dockerfile.applysort
+++ b/bummdidumm_os_v5_final_release/Dockerfile.applysort
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.lock .
+RUN pip install --no-cache-dir --no-deps -r requirements.lock
 # Non-root user (CIS Docker Benchmark)
 RUN useradd --create-home --shell /bin/bash appuser
 COPY --chown=appuser:appuser . .

--- a/bummdidumm_os_v5_final_release/Dockerfile.pass1
+++ b/bummdidumm_os_v5_final_release/Dockerfile.pass1
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.lock .
+RUN pip install --no-cache-dir --no-deps -r requirements.lock
 # Non-root user (CIS Docker Benchmark)
 RUN useradd --create-home --shell /bin/bash appuser
 COPY --chown=appuser:appuser . .

--- a/bummdidumm_os_v5_final_release/Dockerfile.pass2
+++ b/bummdidumm_os_v5_final_release/Dockerfile.pass2
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.lock .
+RUN pip install --no-cache-dir --no-deps -r requirements.lock
 # Non-root user (CIS Docker Benchmark)
 RUN useradd --create-home --shell /bin/bash appuser
 COPY --chown=appuser:appuser . .

--- a/bummdidumm_os_v5_final_release/Dockerfile.renames
+++ b/bummdidumm_os_v5_final_release/Dockerfile.renames
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.lock .
+RUN pip install --no-cache-dir --no-deps -r requirements.lock
 # Non-root user (CIS Docker Benchmark)
 RUN useradd --create-home --shell /bin/bash appuser
 COPY --chown=appuser:appuser . .

--- a/bummdidumm_os_v5_final_release/Dockerfile.safesort
+++ b/bummdidumm_os_v5_final_release/Dockerfile.safesort
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.lock .
+RUN pip install --no-cache-dir --no-deps -r requirements.lock
 # Non-root user (CIS Docker Benchmark)
 RUN useradd --create-home --shell /bin/bash appuser
 COPY --chown=appuser:appuser . .

--- a/bummdidumm_os_v5_final_release/deploy.sh
+++ b/bummdidumm_os_v5_final_release/deploy.sh
@@ -2,15 +2,17 @@
 set -euo pipefail
 
 : "${PROJECT_ID:?Bitte PROJECT_ID setzen}"
+# TARGET_FOLDER_ID is optional — leave empty to scan all monitored folders
 TARGET_FOLDER_ID="${TARGET_FOLDER_ID:-}"
 : "${ARCHIVE_FOLDER_ID:?Bitte ARCHIVE_FOLDER_ID setzen}"
 : "${INDEX_FOLDER_ID:?Bitte INDEX_FOLDER_ID setzen}"
 : "${CONTROL_SHEET_ID:?Bitte CONTROL_SHEET_ID setzen}"
 : "${GEMINI_API_KEY:?Bitte GEMINI_API_KEY setzen}"
+: "${SA_EMAIL:?Bitte SA_EMAIL setzen (z.B. runner@PROJECT_ID.iam.gserviceaccount.com)}"
+: "${BRAIN_INDEX_ROOT:?Bitte BRAIN_INDEX_ROOT setzen (persistenter Pfad oder gemountetes Volume fuer Pass 2 und Safe Sort)}"
 
 REGION="${REGION:-europe-west6}"
 SKIP_OVER_MB="${SKIP_OVER_MB:-500}"
-SA_EMAIL="${SA_EMAIL:-bummdidumm-runner@${PROJECT_ID}.iam.gserviceaccount.com}"
 
 echo "Deploying bummdidumm-OS V5 to Cloud Run Jobs for Project: $PROJECT_ID"
 
@@ -26,7 +28,7 @@ gcloud run jobs deploy bummdidumm-pass2-ocr-index \
   --source . \
   --region "$REGION" \
   --service-account "$SA_EMAIL" \
-  --set-env-vars="INDEX_FOLDER_ID=${INDEX_FOLDER_ID},CONTROL_SHEET_ID=${CONTROL_SHEET_ID},GEMINI_API_KEY=${GEMINI_API_KEY},OCR_BUDGET_PER_RUN=${OCR_BUDGET_PER_RUN:-500}" \
+  --set-env-vars="INDEX_FOLDER_ID=${INDEX_FOLDER_ID},CONTROL_SHEET_ID=${CONTROL_SHEET_ID},GEMINI_API_KEY=${GEMINI_API_KEY},OCR_BUDGET_PER_RUN=${OCR_BUDGET_PER_RUN:-500},BRAIN_INDEX_ROOT=${BRAIN_INDEX_ROOT}" \
   --max-retries=0 --tasks=1 --cpu=1 --memory=2Gi --task-timeout=3600s \
   --command="python","main_pass2.py"
 
@@ -38,7 +40,7 @@ gcloud run jobs deploy bummdidumm-apply-renames \
 
 gcloud run jobs deploy bummdidumm-safe-sort \
   --source . --region "$REGION" --service-account "$SA_EMAIL" \
-  --set-env-vars="CONTROL_SHEET_ID=${CONTROL_SHEET_ID}" \
+  --set-env-vars="CONTROL_SHEET_ID=${CONTROL_SHEET_ID},BRAIN_INDEX_ROOT=${BRAIN_INDEX_ROOT}" \
   --max-retries=0 --tasks=1 --cpu=1 --memory=1Gi --task-timeout=3600s \
   --command="python","main_safe_sort.py"
 

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -166,6 +166,8 @@ def run_pass1():
         # Pass 2 should only pick up this run_id when explicitly signaled.
         state.set_val("ready_for_pass2_run_id", state.run_id)
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
+        state.compact_hash_index()
+        state.compact_reports()
         state.log_run("PASS_1", "SUCCESS", processed, errors)
 
     except Exception as e:

--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -141,8 +141,8 @@ def _build_personal_brain_sources(records_to_index, drive_service, enable_shared
                             sub_local_path = None
                             try:
                                 with tempfile.NamedTemporaryFile(delete=False, suffix=sub_ext) as tf:
-                                    tf.write(z.read(zinfo))
                                     sub_local_path = tf.name
+                                    tf.write(z.read(zinfo))
 
                                 sanitized_name = sanitize_path(zinfo.filename)
                                 sub_detected = inspect_source(

--- a/bummdidumm_os_v5_final_release/release_audit.py
+++ b/bummdidumm_os_v5_final_release/release_audit.py
@@ -88,6 +88,22 @@ def run_audit() -> bool:
         if must.lower() not in gh.lower():
             errors.append(f"Gemini Robustness fehlt: {must}")
 
+    deploy = _read(ROOT / "deploy.sh")
+    if "BRAIN_INDEX_ROOT" not in deploy:
+        errors.append("deploy.sh: BRAIN_INDEX_ROOT fehlt in den Job-Env-Vars")
+    if ': "${SA_EMAIL:?' not in deploy:
+        errors.append("deploy.sh: SA_EMAIL hat kein fail-fast (silent default)")
+
+    if not (ROOT / ".dockerignore").is_file():
+        errors.append(".dockerignore fehlt im Release-Verzeichnis")
+
+    ci = _read(Path(".github") / "workflows" / "personal-brain-gates.yml")
+    if "requirements.lock" not in ci:
+        errors.append("CI nutzt requirements.lock nicht (nutzt requirements.txt)")
+
+    if "compact_hash_index()" not in p1 or "compact_reports()" not in p1:
+        errors.append("Compaction ist nicht im Hauptpfad von Pass 1 verdrahtet")
+
     summary = {"result": "PASS" if not errors else "FAIL", "errors": errors}
     (ROOT / "release_audit.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     (ROOT / "SELF_AUDIT.md").write_text("# Self Audit\n\n" + ("PASS ✅" if not errors else "FAIL ❌") + ("\n\n" + "\n".join(f"- {e}" for e in errors) if errors else "") + "\n", encoding="utf-8")

--- a/bummdidumm_os_v5_final_release/shared/drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/drive_helpers.py
@@ -80,8 +80,11 @@ class DriveManager:
         return name
 
     def walk_recursive(self, folder_id: str) -> List[Dict]:
-        """Performs initial recursive scan."""
-        return []  # Deprecated in favor of chunked processing in main_pass1
+        """Deprecated. Use walk_recursive_chunked() instead."""
+        raise NotImplementedError(
+            "walk_recursive() is deprecated and must not be called. "
+            "Use walk_recursive_chunked() for all production code paths."
+        )
 
     def walk_recursive_chunked(self, folder_id: str, state, process_batch_callback, batch_kwargs: dict):
         """Performs initial recursive scan in bounded chunks to prevent timeout endloops."""

--- a/bummdidumm_os_v5_final_release/shared/state_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/state_helpers.py
@@ -83,6 +83,41 @@ class StateTracker:
         )
         _log.info("Hash_Index kompaktiert", extra={"entries": len(known)})
 
+    def compact_reports(self):
+        """Compact Run_Log and Error_Report by retaining only the most recent rows."""
+        RUN_LOG_MAX = int(os.environ.get("RUN_LOG_COMPACT_MAX", "500"))
+        ERROR_REPORT_MAX = int(os.environ.get("ERROR_REPORT_COMPACT_MAX", "500"))
+
+        for sheet_name, max_rows, col_range in [
+            ("Run_Log", RUN_LOG_MAX, "A:F"),
+            ("Error_Report", ERROR_REPORT_MAX, "A:G"),
+        ]:
+            rows = self.sheets.read_all_rows(sheet_name, col_range)
+            if len(rows) <= max_rows + 1:  # +1 for header
+                continue
+            header = rows[0] if rows else []
+            keep = rows[1:][-max_rows:]
+            compacted = ([header] if header else []) + keep
+            _log.info(f"{sheet_name} Kompaktierung gestartet",
+                      extra={"before": len(rows), "after": len(compacted)})
+            # Clear first to avoid stale trailing rows, then rewrite
+            self.sheets._execute_with_backoff(
+                self.sheets.sheets.spreadsheets().values().clear(
+                    spreadsheetId=self.sheets.spreadsheet_id,
+                    range=f"{sheet_name}!{col_range}",
+                    body={}
+                )
+            )
+            self.sheets._execute_with_backoff(
+                self.sheets.sheets.spreadsheets().values().update(
+                    spreadsheetId=self.sheets.spreadsheet_id,
+                    range=f"{sheet_name}!A1",
+                    valueInputOption="RAW",
+                    body={"values": compacted}
+                )
+            )
+            _log.info(f"{sheet_name} kompaktiert", extra={"kept": len(keep)})
+
     def load_known_hashes(self) -> Dict[str, dict]:
         """Liest den Hash_Index vollständig aus und liefert ein Dictionary {file_id: {vollständiges Schema}}."""
         if self._known_hashes is not None:


### PR DESCRIPTION
- deploy.sh: add BRAIN_INDEX_ROOT as fail-fast required var; make
  SA_EMAIL fail-fast (remove silent default); pass BRAIN_INDEX_ROOT
  to Pass2 and Safe-Sort jobs; add explicit comment for optional
  TARGET_FOLDER_ID

- state_helpers.py: add compact_reports() method that compacts
  Run_Log and Error_Report using clear+update to avoid stale trailing
  rows, with configurable retention thresholds via env vars

- main_pass1.py: wire compact_hash_index() and compact_reports()
  into the Pass 1 success path before log_run()

- drive_helpers.py: replace silent walk_recursive() stub (return [])
  with NotImplementedError to fail fast on any accidental call

- main_pass2.py: fix ZIP sub-file tempfile cleanup leak — set
  sub_local_path = tf.name before tf.write() so finally block can
  clean up even if write raises

- CI (personal-brain-gates.yml): switch pip install and pip-audit
  from requirements.txt to requirements.lock with --no-deps

- Dockerfiles (all 5): switch COPY/RUN from requirements.txt to
  requirements.lock with --no-deps

- .dockerignore: new file — excludes tests/, docs, shell scripts,
  Dockerfiles, __pycache__, .env, and appsscript/ from images

- release_audit.py: add five new consistency checks — BRAIN_INDEX_ROOT
  in deploy.sh, SA_EMAIL fail-fast in deploy.sh, .dockerignore
  existence, CI using requirements.lock, compaction wired in Pass 1

- README.md: add Cloud Run Environment Variables section with full
  variable table and BRAIN_INDEX_ROOT mandatory-mount documentation

All 55 tests pass. release_audit.py: PASS.

https://claude.ai/code/session_01LQYcpJJWUkCsuy7MvqagBy