### PR TITLE
🎨 Palette: Add confirmation dialogs for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-04-14 - Destructive Action Confirmation
+
+**Learning:** Destructive Google Workspace actions triggered by custom menus (e.g., file renaming, applying sorts, clearing error reports) can lead to accidental data loss if invoked by a mistaken click.
+
+**Action:** Always add YES/NO confirmations via `SpreadsheetApp.getUi().alert()` before executing destructive Google Workspace actions triggered by custom menus.

--- a/bummdidumm_os_v5_final_release/appsscript/Code.gs
+++ b/bummdidumm_os_v5_final_release/appsscript/Code.gs
@@ -160,9 +160,21 @@ function handleJobAlert(jobName) {
 
 function startFastDeltaScan() { handleJobAlert("bummdidumm-pass1-delta-dedupe"); }
 function startOcrIndexing() { handleJobAlert("bummdidumm-pass2-ocr-index"); }
-function startApplyRenames() { handleJobAlert("bummdidumm-apply-renames"); }
+function startApplyRenames() {
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.alert("Renames anwenden", "Möchtest du die Umbenennungen wirklich anwenden?", ui.ButtonSet.YES_NO);
+  if (response === ui.Button.YES) {
+    handleJobAlert("bummdidumm-apply-renames");
+  }
+}
 function startSafeSort() { handleJobAlert("bummdidumm-safe-sort"); }
-function startApplySort() { handleJobAlert("bummdidumm-apply-sort"); }
+function startApplySort() {
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.alert("Sortierung anwenden", "Möchtest du die Sortierung wirklich anwenden?", ui.ButtonSet.YES_NO);
+  if (response === ui.Button.YES) {
+    handleJobAlert("bummdidumm-apply-sort");
+  }
+}
 
 function startFullRun() {
   const res = triggerJob("bummdidumm-pass1-delta-dedupe");
@@ -178,9 +190,13 @@ function startFullRun() {
 }
 
 function clearErrorReports() {
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Error_Report");
-  if (!sheet || sheet.getLastRow() <= 1) return;
-  sheet.getRange(2, 1, sheet.getLastRow() - 1, sheet.getLastColumn()).clearContent();
+  const ui = SpreadsheetApp.getUi();
+  const response = ui.alert("Error Reports leeren", "Möchtest du die Error Reports wirklich leeren?", ui.ButtonSet.YES_NO);
+  if (response === ui.Button.YES) {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Error_Report");
+    if (!sheet || sheet.getLastRow() <= 1) return;
+    sheet.getRange(2, 1, sheet.getLastRow() - 1, sheet.getLastColumn()).clearContent();
+  }
 }
 
 function onOpen() {


### PR DESCRIPTION
💡 What: Added YES/NO confirmation dialogs to destructive Google Apps Script functions (`startApplyRenames`, `startApplySort`, `clearErrorReports`).
🎯 Why: To prevent accidental data loss or disruption caused by users accidentally clicking these items in the custom Google Sheets menu.
📸 Before/After: Not a visual change, but introduces a native AppsScript dialog flow before triggering cloud jobs or clearing spreadsheet contents.
♿ Accessibility: N/A, standard AppsScript functionality.

---
*PR created automatically by Jules for task [1638490481073318922](https://jules.google.com/task/1638490481073318922) started by @bummdidumm*