### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix temporary file resource leaks (DoS risk)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-14 - Fix temporary file leak during retryable downloads and ZIP extraction
+**Vulnerability:** Local Denial of Service (DoS) due to unbounded temporary file creation when HTTP downloads loop on retryable errors (like 429 Too Many Requests) and during corrupted ZIP extraction without capturing the `tf.name` before `tf.write()`.
+**Learning:** In `main_pass2.py`, Python `continue` statements inside `except` blocks bypassed local cleanup logic causing `tmp_path` to orphan on disk. Additionally, in ZIP loops, creating the `tf` but failing on `.write()` meant `sub_local_path` remained `None`, thus escaping the `finally` cleanup block.
+**Prevention:** Ensure temporary file unlinking (`os.remove`) executes *before* loop control flow operations (like `continue`) when retrying network operations. When extracting bytes to a temp file, assign the file name to a cleanup-tracked variable before initiating blocking write operations.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Local Denial of Service (DoS) vulnerability via disk exhaustion. If network retryable errors (e.g. 429) occurred repeatedly, the temporary files generated were orphaned because the local `continue` bypassed the local cleanup logic. Similarly, in ZIP extraction loops, if a write error occurred, the name of the created temp file was never recorded, and therefore escaping the final cleanup logic.
🎯 Impact: Large repositories or heavily throttled accounts could exhaust container or local disk storage with orphaned `.tmp` files.
🔧 Fix: Relocated `os.remove(tmp_path)` within the retry loop exception handler before the `continue` is executed. In the inner ZIP extraction, assigned the `tf.name` before invoking `tf.write(z.read(zinfo))`.
✅ Verification: Ran full `pytest` suite ensuring 100% tests pass and verified the pre-commit checks.

---
*PR created automatically by Jules for task [4690863724226300103](https://jules.google.com/task/4690863724226300103) started by @bummdidumm*