### PR TITLE
Apply pragmatic code-review optimisations (6 improvements)

### DIFF
--- a/bummdidumm_os_v5_final_release/deploy.sh
+++ b/bummdidumm_os_v5_final_release/deploy.sh
@@ -13,6 +13,7 @@ TARGET_FOLDER_ID="${TARGET_FOLDER_ID:-}"
 
 REGION="${REGION:-europe-west6}"
 SKIP_OVER_MB="${SKIP_OVER_MB:-500}"
+OCR_BUDGET_PER_RUN="${OCR_BUDGET_PER_RUN:-500}"
 
 echo "Deploying bummdidumm-OS V5 to Cloud Run Jobs for Project: $PROJECT_ID"
 
@@ -28,7 +29,7 @@ gcloud run jobs deploy bummdidumm-pass2-ocr-index \
   --source . \
   --region "$REGION" \
   --service-account "$SA_EMAIL" \
-  --set-env-vars="INDEX_FOLDER_ID=${INDEX_FOLDER_ID},CONTROL_SHEET_ID=${CONTROL_SHEET_ID},GEMINI_API_KEY=${GEMINI_API_KEY},OCR_BUDGET_PER_RUN=${OCR_BUDGET_PER_RUN:-500},BRAIN_INDEX_ROOT=${BRAIN_INDEX_ROOT}" \
+  --set-env-vars="INDEX_FOLDER_ID=${INDEX_FOLDER_ID},CONTROL_SHEET_ID=${CONTROL_SHEET_ID},GEMINI_API_KEY=${GEMINI_API_KEY},OCR_BUDGET_PER_RUN=${OCR_BUDGET_PER_RUN},BRAIN_INDEX_ROOT=${BRAIN_INDEX_ROOT}" \
   --max-retries=0 --tasks=1 --cpu=1 --memory=2Gi --task-timeout=3600s \
   --command="python","main_pass2.py"
 

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -9,7 +9,7 @@ from shared.state_helpers import StateTracker
 from shared.drive_helpers import DriveManager
 from shared.hash_helpers import calculate_sha256_streaming
 from shared.change_type_logic import determine_change_type, check_md5_size_prefilter
-from shared.models import FileRecord
+from shared.models import FileRecord, KnownFileMeta
 
 _module_log = _logging.getLogger("bummdidumm.pass1")
 
@@ -258,7 +258,7 @@ def _process_file_batch(
     drive_mgr,
     state,
     files,
-    known_file_details,
+    known_file_details: dict[str, KnownFileMeta],
     is_initial,
     inbox_trash_folder_id: str,
     folder_registry: dict = None,
@@ -279,70 +279,56 @@ def _process_file_batch(
     records_to_process = []
     duplicate_groups_accumulator = {}
 
-    for f in files:
-        rec = _build_file_record(
-            f, drive_mgr, known_file_details, is_initial,
-            inbox_trash_folder_id, folder_registry,
-        )
-        file_id = rec.file_id
-        change_type = rec.change_type
+    # ------------------------------------------------------------------ #
+    # Inner helpers – closures over the mutable accumulators above.       #
+    # Each helper handles one change-type branch and appends to           #
+    # records_to_process / updates known_file_details as needed.          #
+    # ------------------------------------------------------------------ #
 
-        if change_type in ["REMOVED_OR_NO_ACCESS", "TRASHED", "DELETED"]:
-            rec.status = change_type
-            records_to_process.append(rec)
-            continue
+    def _make_cache_entry(rec: FileRecord) -> KnownFileMeta:
+        return {
+            "sha": rec.sha256,
+            "name": rec.name,
+            "parent_ids_sorted": rec.parent_ids_sorted,
+            "path_display": rec.path_display,
+            "updated_at": rec.updated_at,
+            "size_bytes": rec.size_bytes,
+            "md5": rec.md5,
+            "effective_mime_type": rec.effective_mime_type,
+        }
 
-        # Wenn sich Inhalte nicht geändert haben (UNCHANGED_CONTENT_METADATA_ONLY) ODER
-        # wenn ein MOVED/RENAMED stattfand, bei dem die Binärdaten laut Prefilter
-        # identisch geblieben sind, wollen wir das Hashing überspringen.
-        if change_type == "UNCHANGED_CONTENT_METADATA_ONLY" or (not is_initial and check_md5_size_prefilter(f, known_file_details)):
-            rec.status = "UNCHANGED_CONTENT"
-            rec.sha256 = known_file_details.get(file_id, {}).get("sha", "")
+    def _handle_removed(rec: FileRecord) -> None:
+        rec.status = rec.change_type
+        records_to_process.append(rec)
 
-            if rec.sha256 == "HASH_SKIPPED_SIZE":
-                rec.status = "SKIPPED_SIZE"
-
-            # Check if file_id exists in cache before updating it.
-            # If it's UNCHANGED_CONTENT but somehow missing in cache, we seed it instead of throwing KeyError.
-            if file_id in known_file_details:
-                known_file_details[file_id].update({
-                    "name": rec.name,
-                    "parent_ids_sorted": rec.parent_ids_sorted,
-                    "path_display": rec.path_display,
-                    "updated_at": rec.updated_at
-                })
-            else:
-                known_file_details[file_id] = {
-                    "sha": rec.sha256,
-                    "name": rec.name,
-                    "parent_ids_sorted": rec.parent_ids_sorted,
-                    "path_display": rec.path_display,
-                    "updated_at": rec.updated_at,
-                    "size_bytes": rec.size_bytes,
-                    "md5": rec.md5,
-                    "effective_mime_type": rec.effective_mime_type
-                }
-            records_to_process.append(rec)
-            continue
-
-        if rec.size_bytes > SKIP_OVER_MB * 1024 * 1024:
+    def _handle_unchanged(rec: FileRecord) -> None:
+        rec.status = "UNCHANGED_CONTENT"
+        rec.sha256 = known_file_details.get(rec.file_id, {}).get("sha", "")
+        if rec.sha256 == "HASH_SKIPPED_SIZE":
             rec.status = "SKIPPED_SIZE"
-            rec.sha256 = "HASH_SKIPPED_SIZE"
-            # Update cache sofort für denselben Batch, damit nachfolgende Deltas ihn kennen
-            known_file_details[rec.file_id] = {
-                "sha": rec.sha256,
+        # Update cache metadata; seed entry if somehow missing.
+        if rec.file_id in known_file_details:
+            known_file_details[rec.file_id].update({
                 "name": rec.name,
                 "parent_ids_sorted": rec.parent_ids_sorted,
                 "path_display": rec.path_display,
                 "updated_at": rec.updated_at,
-                "size_bytes": rec.size_bytes,
-                "md5": rec.md5,
-                "effective_mime_type": rec.effective_mime_type
-            }
-            records_to_process.append(rec)
-            continue
+            })
+        else:
+            known_file_details[rec.file_id] = _make_cache_entry(rec)
+        records_to_process.append(rec)
 
-        sha, export_source = calculate_sha256_streaming(drive_service, rec.file_id, rec.mime_type, drive_mgr._base_params())
+    def _handle_skipped_size(rec: FileRecord) -> None:
+        rec.status = "SKIPPED_SIZE"
+        rec.sha256 = "HASH_SKIPPED_SIZE"
+        # Update cache sofort für denselben Batch, damit nachfolgende Deltas ihn kennen.
+        known_file_details[rec.file_id] = _make_cache_entry(rec)
+        records_to_process.append(rec)
+
+    def _handle_new_or_updated(rec: FileRecord) -> None:
+        sha, export_source = calculate_sha256_streaming(
+            drive_service, rec.file_id, rec.mime_type, drive_mgr._base_params()
+        )
         rec.sha256 = sha or ""
         rec.export_source = export_source
 
@@ -350,43 +336,51 @@ def _process_file_batch(
             state.log_error("PASS_1", rec.file_id, rec.name, "HashError", "SHA256 fehlgeschlagen")
             rec.status = "HASH_ERROR"
             records_to_process.append(rec)
-            continue
+            return
 
         # Dedupe Logik über Hash Map (O(1))
         duplicate_of_id = sha_to_primary_file_id.get(rec.sha256)
-
         if duplicate_of_id:
-            if duplicate_of_id == rec.file_id:
-                rec.status = "ORIGINAL_RESUMED"
-            else:
-                rec.status = "DUPLICATE"
+            rec.status = "ORIGINAL_RESUMED" if duplicate_of_id == rec.file_id else "DUPLICATE"
+            if rec.status == "DUPLICATE":
                 rec.duplicate_of = duplicate_of_id
         else:
             rec.status = "ORIGINAL"
             sha_to_primary_file_id[rec.sha256] = rec.file_id
-            # Update cache sofort für denselben Batch
-            known_file_details[rec.file_id] = {
-                "sha": rec.sha256,
-                "name": rec.name,
-                "parent_ids_sorted": rec.parent_ids_sorted,
-                "path_display": rec.path_display,
-                "updated_at": rec.updated_at,
-                "size_bytes": rec.size_bytes,
-                "md5": rec.md5,
-                "effective_mime_type": rec.effective_mime_type
-            }
+            # Update cache sofort für denselben Batch.
+            known_file_details[rec.file_id] = _make_cache_entry(rec)
 
         if rec.status == "DUPLICATE" and ENABLE_ARCHIVE:
             rec.archive_result = drive_mgr.archive_duplicate(rec.file_id, rec.parents, ARCHIVE_FOLDER_ID)
             if "SUCCESS" in rec.archive_result:
                 rec.status = f"DUPLICATE_OF:{rec.duplicate_of}|ARCHIVED"
-
-                # Accumulate for batched writes
                 if rec.sha256 not in duplicate_groups_accumulator:
                     duplicate_groups_accumulator[rec.sha256] = {"original": rec.duplicate_of, "duplicates": set()}
                 duplicate_groups_accumulator[rec.sha256]["duplicates"].add(rec.file_id)
 
         records_to_process.append(rec)
+
+    # ------------------------------------------------------------------ #
+    # Main dispatch loop                                                  #
+    # ------------------------------------------------------------------ #
+
+    for f in files:
+        rec = _build_file_record(
+            f, drive_mgr, known_file_details, is_initial,
+            inbox_trash_folder_id, folder_registry,
+        )
+        change_type = rec.change_type
+
+        if change_type in ["REMOVED_OR_NO_ACCESS", "TRASHED", "DELETED"]:
+            _handle_removed(rec)
+        elif change_type == "UNCHANGED_CONTENT_METADATA_ONLY" or (
+            not is_initial and check_md5_size_prefilter(f, known_file_details)
+        ):
+            _handle_unchanged(rec)
+        elif rec.size_bytes > SKIP_OVER_MB * 1024 * 1024:
+            _handle_skipped_size(rec)
+        else:
+            _handle_new_or_updated(rec)
 
     state.append_new_hashes(records_to_process)
     state.append_dedupe_reports(records_to_process)

--- a/bummdidumm_os_v5_final_release/main_safe_sort.py
+++ b/bummdidumm_os_v5_final_release/main_safe_sort.py
@@ -47,37 +47,45 @@ def run_safe_sort():
     known = state.load_known_hashes()
     known_file_ids = set(known.keys())
 
-    # Load semantic hints from personal_brain record index.
-    # Only collect hints for file_ids that are already in the known-hashes set
-    # to cap memory usage — the record index can be large on production deployments.
+    # Load semantic hints (file_id → primary topic) for sorting decisions.
+    # Prefer the compact file_topics.json written by Pass 2 writers; fall back to
+    # streaming the full record index for installations that predate this file.
     from pathlib import Path
     import json
     import logging
     semantic_hints: dict[str, str] = {}
     brain_index_root = Path(os.environ.get("BRAIN_INDEX_ROOT", str(Path(__file__).parent / "brain_index")))
     if "K_SERVICE" in os.environ and not os.environ.get("BRAIN_INDEX_ROOT"):
-        log.warning("BRAIN_INDEX_ROOT is not set in Cloud Run. Semantic hints will not be available or persisted correctly.")
+        log.warning("BRAIN_INDEX_ROOT is not set in Cloud Run. Semantic hints will not be available.")
 
-    registry_path = brain_index_root / "20_index" / "published" / "01_record_index.jsonl"
-    if registry_path.exists():
+    hint_path = brain_index_root / "20_index" / "published" / "file_topics.json"
+    if hint_path.exists():
         try:
-            with registry_path.open(encoding="utf-8") as rh:
-                for line in rh:
-                    if not line.strip():
-                        continue
-                    try:
-                        s_data = json.loads(line)
-                        f_id = s_data.get("file_id")
-                        # Skip file_ids not present in the known-hashes set to
-                        # avoid building a large hints dict from stale records.
-                        if f_id and (not known_file_ids or f_id in known_file_ids):
-                            topics = s_data.get("topics", [])
-                            if topics:
-                                semantic_hints[f_id] = topics[0]
-                    except Exception as e:
-                        logging.debug(f"Failed to parse line in record index: {e}")
+            loaded = json.loads(hint_path.read_text(encoding="utf-8"))
+            # Filter to known file_ids to keep the dict bounded.
+            semantic_hints = {k: v for k, v in loaded.items() if not known_file_ids or k in known_file_ids}
         except Exception as e:
-            logging.debug(f"Failed to read record index for semantic hints: {e}")
+            logging.debug(f"Failed to load topic hints file: {e}")
+    else:
+        # Fallback: stream record index (legacy path, before hints file was generated).
+        registry_path = brain_index_root / "20_index" / "published" / "01_record_index.jsonl"
+        if registry_path.exists():
+            try:
+                with registry_path.open(encoding="utf-8") as rh:
+                    for line in rh:
+                        if not line.strip():
+                            continue
+                        try:
+                            s_data = json.loads(line)
+                            f_id = s_data.get("file_id")
+                            if f_id and (not known_file_ids or f_id in known_file_ids):
+                                topics = s_data.get("topics", [])
+                                if topics:
+                                    semantic_hints[f_id] = topics[0]
+                        except Exception as e:
+                            logging.debug(f"Failed to parse line in record index: {e}")
+            except Exception as e:
+                logging.debug(f"Failed to read record index for semantic hints: {e}")
 
     suggestions = []
     processed = 0

--- a/bummdidumm_os_v5_final_release/personal_brain/writers.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/writers.py
@@ -87,18 +87,43 @@ class JsonlWriter:
     # ------------------------------------------------------------------
 
     def _write_jsonl(self, path: Path, rows: list[dict], key: str) -> None:
-        """Read-Merge-Write: new rows overwrite existing rows by stable ID.
-        Entries absent from `rows` but present on disk are preserved.
+        """Streaming-Merge-Write: new rows overwrite existing rows by stable ID.
+
+        Existing rows absent from `rows` are streamed directly to the temp file
+        without being buffered in RAM. Only the incoming `rows` (O(m)) are held
+        in memory, avoiding the previous O(n) full-load for large indices.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
-        merged = self._read_existing(path, key)
-        for row in rows:
-            merged[row[key]] = row
+        new_lookup = {row[key]: row for row in rows}
+
+        if path.exists():
+            file_size = path.stat().st_size
+            if file_size > _LARGE_FILE_WARN_BYTES:
+                _log.warning(
+                    "Large JSONL index file detected — RAM pressure possible on merge",
+                    extra={"path": str(path), "size_mb": round(file_size / 1024 / 1024, 1)},
+                )
 
         tmp_path = path.with_suffix(".tmp")
-        with tmp_path.open("w", encoding="utf-8") as f:
-            for k in sorted(merged):
-                f.write(json.dumps(merged[k], ensure_ascii=False) + "\n")
+        with tmp_path.open("w", encoding="utf-8") as out:
+            if path.exists():
+                with path.open(encoding="utf-8") as fh:
+                    for line_num, line in enumerate(fh, 1):
+                        stripped = line.strip()
+                        if not stripped:
+                            continue
+                        try:
+                            row = json.loads(stripped)
+                            k = row.get(key)
+                            if k not in new_lookup:
+                                out.write(stripped + "\n")
+                        except Exception as e:
+                            _log.warning(
+                                "Skipping corrupt line in JSONL",
+                                extra={"path": str(path), "line": line_num, "error": str(e)},
+                            )
+            for k in sorted(new_lookup):
+                out.write(json.dumps(new_lookup[k], ensure_ascii=False) + "\n")
         tmp_path.replace(path)
 
     def _merge_entities(self, merged: dict, new_entity: dict) -> None:
@@ -171,26 +196,67 @@ class JsonlWriter:
         self._write_jsonl(self.published / "00_source_registry.jsonl", sources, "source_id")
         self._write_jsonl(self.published / "01_record_index.jsonl", records, "record_id")
 
-        # Custom merge logic for entities
+        # Custom merge logic for entities — single-pass streaming to keep RAM at O(m).
+        # Existing entities that match an incoming entity_id are merged in place and
+        # written out; all others are streamed through without buffering.
         entity_path = self.published / "02_entity_index.jsonl"
         entity_path.parent.mkdir(parents=True, exist_ok=True)
-        merged_entities: dict = self._read_existing(entity_path, "entity_id")
-
-        for new_ent in entities:
-            eid = new_ent["entity_id"]
-            if eid in merged_entities:
-                self._merge_entities(merged_entities[eid], new_ent)
-            else:
-                merged_entities[eid] = new_ent
+        new_entity_lookup = {e["entity_id"]: e for e in entities}
 
         tmp_entity_path = entity_path.with_suffix(".tmp")
-        with tmp_entity_path.open("w", encoding="utf-8") as f:
-            for k in sorted(merged_entities):
-                clean = {ek: ev for ek, ev in merged_entities[k].items() if not ek.startswith("_") or ek == "_counts_by_source"}
-                f.write(json.dumps(clean, ensure_ascii=False) + "\n")
+        with tmp_entity_path.open("w", encoding="utf-8") as out:
+            if entity_path.exists():
+                with entity_path.open(encoding="utf-8") as fh:
+                    for line_num, line in enumerate(fh, 1):
+                        stripped = line.strip()
+                        if not stripped:
+                            continue
+                        try:
+                            existing_ent = json.loads(stripped)
+                            eid = existing_ent.get("entity_id")
+                            if eid in new_entity_lookup:
+                                self._merge_entities(existing_ent, new_entity_lookup.pop(eid))
+                                clean = {ek: ev for ek, ev in existing_ent.items()
+                                         if not ek.startswith("_") or ek == "_counts_by_source"}
+                                out.write(json.dumps(clean, ensure_ascii=False) + "\n")
+                            else:
+                                out.write(stripped + "\n")
+                        except Exception as e:
+                            _log.warning(
+                                "Skipping corrupt entity line",
+                                extra={"path": str(entity_path), "line": line_num, "error": str(e)},
+                            )
+            for k in sorted(new_entity_lookup):
+                clean = {ek: ev for ek, ev in new_entity_lookup[k].items()
+                         if not ek.startswith("_") or ek == "_counts_by_source"}
+                out.write(json.dumps(clean, ensure_ascii=False) + "\n")
         tmp_entity_path.replace(entity_path)
 
         self._write_jsonl(self.published / "03_relation_index.jsonl", relations, "relation_id")
+        self._write_topic_hints(records)
+
+    def _write_topic_hints(self, records: list[dict]) -> None:
+        """Maintain a compact file_id→topic lookup used by main_safe_sort.py.
+
+        Merges with existing hints so partial re-runs don't erase previous data.
+        The resulting file_topics.json is orders of magnitude smaller than the
+        full record index, making Safe Sort startup much faster.
+        """
+        hint_path = self.published / "file_topics.json"
+        existing: dict[str, str] = {}
+        if hint_path.exists():
+            try:
+                existing = json.loads(hint_path.read_text(encoding="utf-8"))
+            except Exception as e:
+                _log.warning("Could not load existing topic hints", extra={"error": str(e)})
+        for rec in records:
+            fid = rec.get("file_id")
+            topics = rec.get("topics", [])
+            if fid and topics:
+                existing[fid] = topics[0]
+        tmp = hint_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(existing, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(hint_path)
 
     def write_daily_memory(self, _records: list[dict]) -> dict[str, dict]:
         """Rebuild daily memory from the full merged record index.
@@ -220,8 +286,8 @@ class JsonlWriter:
                 if f.is_file():
                     try:
                         daily_memories[f.stem] = _json.loads(f.read_text(encoding="utf-8"))
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        _log.debug("Skipping unreadable daily memory file", extra={"file": str(f), "error": str(e)})
         weekly = build_weekly_memory(daily_memories)
         weekly_dir = self.published / "04_weekly_memory"
         weekly_dir.mkdir(parents=True, exist_ok=True)
@@ -364,8 +430,8 @@ class JsonlWriter:
                             mf.write(json.dumps(f.stem, ensure_ascii=False) + ":")
                             json.dump(day_data, mf, ensure_ascii=False)
                             first = False
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            _log.debug("Skipping unreadable daily memory entry in master index", extra={"file": str(f), "error": str(e)})
             mf.write("}")
 
             # Search views
@@ -380,8 +446,8 @@ class JsonlWriter:
                             if line.strip():
                                 try:
                                     view_rows.append(json.loads(line))
-                                except Exception:
-                                    pass
+                                except Exception as e:
+                                    _log.debug("Skipping corrupt search view line", extra={"file": str(f), "error": str(e)})
                         if not first:
                             mf.write(",")
                         mf.write(json.dumps(f.stem, ensure_ascii=False) + ":")

--- a/bummdidumm_os_v5_final_release/shared/models.py
+++ b/bummdidumm_os_v5_final_release/shared/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional, List, TypedDict
 
 class ExtractedDocument(BaseModel):
     doc_type: str = Field(description="Art des Dokuments: Rechnung, Vertrag, Brief, Foto, Ausweis, Quittung, Versicherung, Kontoauszug, Sonstiges")
@@ -78,3 +78,19 @@ class FileRecord(BaseModel):
     can_edit: bool = True
     can_share: bool = True
     can_download: bool = True
+
+
+class KnownFileMeta(TypedDict, total=False):
+    """Shape of the per-file metadata cache entry used throughout Pass 1.
+
+    Stored in the `known_file_details` dict keyed by file_id and also
+    persisted to the Sheets hash-index via StateTracker.
+    """
+    sha: str
+    name: str
+    parent_ids_sorted: str
+    path_display: str
+    updated_at: str
+    size_bytes: int
+    md5: str
+    effective_mime_type: str


### PR DESCRIPTION
1. writers.py – streaming merge: _write_jsonl and the entity write path
   in write_source_record_entity_relation now stream existing JSONL lines
   directly to the temp file instead of loading them all into RAM.
   Peak memory drops from O(n_total) to O(m_new_rows) for partial reruns.

2. writers.py – topic hints file: new _write_topic_hints() method writes a
   compact file_id→topic JSON alongside the record index after each Pass 2
   run, accumulating across partial reruns.

3. main_safe_sort.py – load from file_topics.json when present (fast path,
   a few KB vs potentially hundreds of MB); fall back to streaming the full
   record index for pre-existing deployments.

4. shared/models.py – add KnownFileMeta TypedDict documenting the shape of
   the per-file cache entries threaded through Pass 1.

5. main_pass1.py – refactor _process_file_batch: extract four inner helper
   closures (_handle_removed, _handle_unchanged, _handle_skipped_size,
   _handle_new_or_updated) and a shared _make_cache_entry() to reduce the
   function from 137 lines to a clean dispatch loop; add KnownFileMeta
   annotation to the known_file_details parameter.

6. writers.py / deploy.sh – replace three bare `except: pass` blocks with
   _log.debug() calls; extract OCR_BUDGET_PER_RUN as a named variable with
   default in deploy.sh for symmetry with SKIP_OVER_MB.

73/74 tests pass; the 1 remaining failure is a pre-existing system-level
cryptography/cffi breakage in the local environment unrelated to these changes.

https://claude.ai/code/session_01HLq1JKBz7i3ZPwFwc6diYo