### PR TITLE
Harden pipeline run coordination, state flushes, and Drive retries

### DIFF
--- a/bummdidumm_os_v5_final_release/main_apply_renames.py
+++ b/bummdidumm_os_v5_final_release/main_apply_renames.py
@@ -26,11 +26,14 @@ def run_apply_renames():
     log.info("Rename Job gestartet")
 
     state.set_val("current_phase", "APPLY_RENAMES")
+    state.flush_state()
 
     current_run_id = state.get_val("last_successful_run_id")
 
     if not current_run_id:
         state.log_error("RENAME", "SYSTEM", "", "NoRunID", "Kein aktueller Run_ID gefunden.")
+        state.set_val("current_phase", "IDLE")
+        state.flush_state()
         return
 
     processed = 0
@@ -64,6 +67,7 @@ def run_apply_renames():
 
     state.log_run("RENAME", "SUCCESS", processed, errors)
     state.set_val("current_phase", "IDLE")
+    state.flush_state()
 
 if __name__ == "__main__":
     run_apply_renames()

--- a/bummdidumm_os_v5_final_release/main_apply_sort.py
+++ b/bummdidumm_os_v5_final_release/main_apply_sort.py
@@ -27,9 +27,12 @@ def run_apply_sort():
     log.info("Apply Sort gestartet")
 
     state.set_val("current_phase", "APPLY_SORT")
+    state.flush_state()
     current_run_id = state.get_val("last_successful_run_id")
     if not current_run_id:
         state.log_error("APPLY_SORT", "SYSTEM", "", "NoRunID", "Kein aktueller Run_ID gefunden.")
+        state.set_val("current_phase", "IDLE")
+        state.flush_state()
         return
 
     processed = 0
@@ -109,6 +112,7 @@ def run_apply_sort():
 
     state.log_run("APPLY_SORT", "SUCCESS", processed, errors)
     state.set_val("current_phase", "IDLE")
+    state.flush_state()
     log.info("Apply Sort beendet", extra={"processed": processed, "errors": errors})
 
 

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -49,32 +49,53 @@ def run_pass1():
 
     start_token = state.get_val("drive_start_page_token")
     in_progress_token = state.get_val("in_progress_page_token")
+    lease_timeout_sec = int(os.environ.get("RUN_LEASE_TIMEOUT_SEC", "3600"))
 
-    # GUARD: Prevent parallel runs overlapping logic
-    # Difference between legitimate resume vs competing start:
-    # A legitimate resume occurs if state.run_id matches state.get_val("run_id").
-    # If not, another instance might still be processing. We must abort to prevent state corruption.
+    def _touch_lease():
+        state.set_val("lease_owner_id", state.owner_id)
+        state.set_val("lease_heartbeat_at", datetime.now(timezone.utc).isoformat())
+        state.set_val("run_id", state.run_id)
+        state.flush_state()
+
+    # GUARD: Prevent parallel runs overlapping logic via lease owner + heartbeat.
     current_phase = state.get_val("current_phase")
+    existing_owner = state.get_val("lease_owner_id")
     existing_run_id = state.get_val("run_id")
 
-    if current_phase in ["INITIAL_SCAN", "DELTA_FETCH"] and existing_run_id and existing_run_id != state.run_id:
-        # check if it is stale > 1 hours, then we take over.
-        last_utc_str = state.get_val("last_run_utc")
+    if current_phase in ["INITIAL_SCAN", "DELTA_FETCH"] and existing_owner and existing_owner != state.owner_id:
+        # check if it is stale, then we take over.
+        heartbeat_utc_str = state.get_val("lease_heartbeat_at") or state.get_val("last_run_utc")
         is_stale = False
-        if last_utc_str:
+        if heartbeat_utc_str:
             try:
-                last_t = datetime.fromisoformat(last_utc_str)
+                last_t = datetime.fromisoformat(heartbeat_utc_str)
                 diff = (datetime.now(timezone.utc) - last_t).total_seconds()
-                if diff >= 3600:
+                if diff >= lease_timeout_sec:
                     is_stale = True
             except ValueError:
                 pass
 
         if not is_stale:
-            log.warning("Parallel-Run Guard: Es läuft bereits ein aktiver Pass 1 Lauf. Breche Start ab um Korruption zu vermeiden.", extra={"active_run": existing_run_id, "my_run": state.run_id})
+            log.warning(
+                "Parallel-Run Guard: Aktiver Lease erkannt. Breche Start ab um Korruption zu vermeiden.",
+                extra={"active_owner": existing_owner, "active_run": existing_run_id, "my_owner": state.owner_id, "my_run": state.run_id},
+            )
             return
         else:
-            log.warning("Parallel-Run Guard: Stale Run erkannt (> 1h alt). Übernehme Ausführung.", extra={"stale_run": existing_run_id, "my_run": state.run_id})
+            log.warning(
+                "Parallel-Run Guard: Stale Lease erkannt. Übernehme Ausführung.",
+                extra={"stale_owner": existing_owner, "stale_run": existing_run_id, "my_owner": state.owner_id, "my_run": state.run_id},
+            )
+
+    state.set_val("lease_owner_id", state.owner_id)
+    state.set_val("lease_acquired_at", datetime.now(timezone.utc).isoformat())
+    state.set_val("lease_heartbeat_at", datetime.now(timezone.utc).isoformat())
+    state.set_val("run_id", state.run_id)
+    state.flush_state()
+    state.reload_state()
+    if state.get_val("lease_owner_id") != state.owner_id:
+        log.warning("Parallel-Run Guard: Lease-Konkurrenz erkannt, Start abgebrochen.")
+        return
 
     # 1. Load known state for heuristics
     known_file_details = state.load_known_hashes()
@@ -152,6 +173,7 @@ def run_pass1():
                 if next_token:
                     active_token = next_token
                     state.set_val("in_progress_page_token", active_token)
+                    _touch_lease()
                 else:
                     new_start_page_token = new_start
                     break
@@ -166,12 +188,19 @@ def run_pass1():
         # Pass 2 should only pick up this run_id when explicitly signaled.
         state.set_val("ready_for_pass2_run_id", state.run_id)
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
+        state.set_val("lease_owner_id", "")
+        state.set_val("lease_heartbeat_at", "")
+        state.flush_state()
         state.compact_hash_index()
         state.compact_reports()
         state.log_run("PASS_1", "SUCCESS", processed, errors)
 
     except Exception as e:
         state.set_val("current_phase", "PASS1_FAILED")
+        state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
+        state.set_val("lease_owner_id", "")
+        state.set_val("lease_heartbeat_at", "")
+        state.flush_state()
         state.log_error("PASS_1", "SYSTEM", "", "Fatal", str(e))
         state.log_run("PASS_1", "FAILED", processed, errors + 1)
         raise e

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -32,6 +32,64 @@ def suggest_rename(name: str, created_time: str, project_slug: str = PROJECT_SLU
     safe = name.replace(":", "-").strip()
     return f"{iso_date}_{project_slug}_{safe}"
 
+
+def _is_lease_stale(state, lease_timeout_sec: int) -> bool:
+    heartbeat_utc_str = (
+        state.get_val("lease_heartbeat_at")
+        or state.get_val("lease_acquired_at")
+        or state.get_val("last_run_utc")
+    )
+    if not heartbeat_utc_str:
+        return False
+    try:
+        last_t = datetime.fromisoformat(heartbeat_utc_str)
+    except ValueError:
+        return False
+    diff = (datetime.now(timezone.utc) - last_t).total_seconds()
+    return diff >= lease_timeout_sec
+
+
+def _touch_lease(state):
+    now_utc = datetime.now(timezone.utc).isoformat()
+    state.set_val("lease_owner_id", state.owner_id)
+    if not state.get_val("lease_acquired_at"):
+        state.set_val("lease_acquired_at", now_utc)
+    state.set_val("lease_heartbeat_at", now_utc)
+    state.set_val("run_id", state.run_id)
+    state.flush_state()
+
+
+def _release_lease(state):
+    state.set_val("lease_owner_id", "")
+    state.set_val("lease_heartbeat_at", "")
+    state.set_val("lease_acquired_at", "")
+
+
+def _acquire_lease_or_abort(state, log, lease_timeout_sec: int) -> bool:
+    existing_owner = state.get_val("lease_owner_id")
+    existing_run_id = state.get_val("run_id")
+    existing_phase = state.get_val("current_phase")
+
+    if existing_owner and existing_owner != state.owner_id and not _is_lease_stale(state, lease_timeout_sec):
+        log.warning(
+            "Parallel-Run Guard: Aktiver Lease erkannt. Breche Start ab um Korruption zu vermeiden.",
+            extra={
+                "active_owner": existing_owner,
+                "active_run": existing_run_id,
+                "active_phase": existing_phase,
+                "my_owner": state.owner_id,
+                "my_run": state.run_id,
+            },
+        )
+        return False
+
+    _touch_lease(state)
+    state.reload_state()
+    if state.get_val("lease_owner_id") != state.owner_id:
+        log.warning("Parallel-Run Guard: Lease-Konkurrenz erkannt, Start abgebrochen.")
+        return False
+    return True
+
 def run_pass1():
     if not CONTROL_SHEET_ID:
         raise ValueError("Missing CONTROL_SHEET_ID")
@@ -51,50 +109,7 @@ def run_pass1():
     in_progress_token = state.get_val("in_progress_page_token")
     lease_timeout_sec = int(os.environ.get("RUN_LEASE_TIMEOUT_SEC", "3600"))
 
-    def _touch_lease():
-        state.set_val("lease_owner_id", state.owner_id)
-        state.set_val("lease_heartbeat_at", datetime.now(timezone.utc).isoformat())
-        state.set_val("run_id", state.run_id)
-        state.flush_state()
-
-    # GUARD: Prevent parallel runs overlapping logic via lease owner + heartbeat.
-    current_phase = state.get_val("current_phase")
-    existing_owner = state.get_val("lease_owner_id")
-    existing_run_id = state.get_val("run_id")
-
-    if current_phase in ["INITIAL_SCAN", "DELTA_FETCH"] and existing_owner and existing_owner != state.owner_id:
-        # check if it is stale, then we take over.
-        heartbeat_utc_str = state.get_val("lease_heartbeat_at") or state.get_val("last_run_utc")
-        is_stale = False
-        if heartbeat_utc_str:
-            try:
-                last_t = datetime.fromisoformat(heartbeat_utc_str)
-                diff = (datetime.now(timezone.utc) - last_t).total_seconds()
-                if diff >= lease_timeout_sec:
-                    is_stale = True
-            except ValueError:
-                pass
-
-        if not is_stale:
-            log.warning(
-                "Parallel-Run Guard: Aktiver Lease erkannt. Breche Start ab um Korruption zu vermeiden.",
-                extra={"active_owner": existing_owner, "active_run": existing_run_id, "my_owner": state.owner_id, "my_run": state.run_id},
-            )
-            return
-        else:
-            log.warning(
-                "Parallel-Run Guard: Stale Lease erkannt. Übernehme Ausführung.",
-                extra={"stale_owner": existing_owner, "stale_run": existing_run_id, "my_owner": state.owner_id, "my_run": state.run_id},
-            )
-
-    state.set_val("lease_owner_id", state.owner_id)
-    state.set_val("lease_acquired_at", datetime.now(timezone.utc).isoformat())
-    state.set_val("lease_heartbeat_at", datetime.now(timezone.utc).isoformat())
-    state.set_val("run_id", state.run_id)
-    state.flush_state()
-    state.reload_state()
-    if state.get_val("lease_owner_id") != state.owner_id:
-        log.warning("Parallel-Run Guard: Lease-Konkurrenz erkannt, Start abgebrochen.")
+    if not _acquire_lease_or_abort(state, log, lease_timeout_sec):
         return
 
     # 1. Load known state for heuristics
@@ -137,7 +152,7 @@ def run_pass1():
             }
 
             processed = drive_mgr.walk_recursive_chunked(
-                TARGET_FOLDER_ID, state, _process_file_batch_wrapper, kwargs
+                TARGET_FOLDER_ID, state, _process_file_batch_wrapper, kwargs, lease_touch_callback=lambda: _touch_lease(state)
             )
 
             state.set_val("drive_start_page_token", new_start_page_token)
@@ -153,6 +168,7 @@ def run_pass1():
             new_start_page_token = None
 
             while active_token:
+                _touch_lease(state)
                 log.debug("Delta Chunk", extra={"token": active_token})
                 changes, next_token, new_start = drive_mgr.fetch_delta_chunk(active_token)
                 files = [f for f in changes if f.get("mimeType") != "application/vnd.google-apps.folder"]
@@ -173,7 +189,6 @@ def run_pass1():
                 if next_token:
                     active_token = next_token
                     state.set_val("in_progress_page_token", active_token)
-                    _touch_lease()
                 else:
                     new_start_page_token = new_start
                     break
@@ -188,8 +203,7 @@ def run_pass1():
         # Pass 2 should only pick up this run_id when explicitly signaled.
         state.set_val("ready_for_pass2_run_id", state.run_id)
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
-        state.set_val("lease_owner_id", "")
-        state.set_val("lease_heartbeat_at", "")
+        _release_lease(state)
         state.flush_state()
         state.compact_hash_index()
         state.compact_reports()
@@ -198,8 +212,7 @@ def run_pass1():
     except Exception as e:
         state.set_val("current_phase", "PASS1_FAILED")
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
-        state.set_val("lease_owner_id", "")
-        state.set_val("lease_heartbeat_at", "")
+        _release_lease(state)
         state.flush_state()
         state.log_error("PASS_1", "SYSTEM", "", "Fatal", str(e))
         state.log_run("PASS_1", "FAILED", processed, errors + 1)

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -49,23 +49,41 @@ def _is_lease_stale(state, lease_timeout_sec: int) -> bool:
     return diff >= lease_timeout_sec
 
 
-def _touch_lease(state):
+def _claim_lease(state):
     now_utc = datetime.now(timezone.utc).isoformat()
     state.set_val("lease_owner_id", state.owner_id)
-    if not state.get_val("lease_acquired_at"):
-        state.set_val("lease_acquired_at", now_utc)
+    state.set_val("lease_acquired_at", now_utc)
     state.set_val("lease_heartbeat_at", now_utc)
     state.set_val("run_id", state.run_id)
     state.flush_state()
 
 
+def _touch_lease(state) -> bool:
+    state.reload_state()
+    if state.get_val("lease_owner_id") != state.owner_id:
+        return False
+    now_utc = datetime.now(timezone.utc).isoformat()
+    state.set_val("lease_heartbeat_at", now_utc)
+    state.flush_state()
+    return True
+
+
 def _release_lease(state):
+    state.reload_state()
+    if state.get_val("lease_owner_id") != state.owner_id:
+        return
     state.set_val("lease_owner_id", "")
     state.set_val("lease_heartbeat_at", "")
     state.set_val("lease_acquired_at", "")
 
 
+def _touch_lease_or_raise(state, context: str):
+    if not _touch_lease(state):
+        raise RuntimeError(f"Lease verloren während {context}")
+
+
 def _acquire_lease_or_abort(state, log, lease_timeout_sec: int) -> bool:
+    state.reload_state()
     existing_owner = state.get_val("lease_owner_id")
     existing_run_id = state.get_val("run_id")
     existing_phase = state.get_val("current_phase")
@@ -83,10 +101,19 @@ def _acquire_lease_or_abort(state, log, lease_timeout_sec: int) -> bool:
         )
         return False
 
-    _touch_lease(state)
+    if existing_run_id and (
+        (existing_owner and existing_owner != state.owner_id and _is_lease_stale(state, lease_timeout_sec))
+        or (not existing_owner and existing_phase in ["INITIAL_SCAN", "DELTA_FETCH"])
+    ):
+        state.run_id = existing_run_id
+
+    _claim_lease(state)
     state.reload_state()
     if state.get_val("lease_owner_id") != state.owner_id:
         log.warning("Parallel-Run Guard: Lease-Konkurrenz erkannt, Start abgebrochen.")
+        return False
+    if state.get_val("run_id") != state.run_id:
+        log.warning("Parallel-Run Guard: run_id-Konkurrenz erkannt, Start abgebrochen.")
         return False
     return True
 
@@ -152,7 +179,11 @@ def run_pass1():
             }
 
             processed = drive_mgr.walk_recursive_chunked(
-                TARGET_FOLDER_ID, state, _process_file_batch_wrapper, kwargs, lease_touch_callback=lambda: _touch_lease(state)
+                TARGET_FOLDER_ID,
+                state,
+                _process_file_batch_wrapper,
+                kwargs,
+                lease_touch_callback=lambda: _touch_lease_or_raise(state, "Initial-Scan"),
             )
 
             state.set_val("drive_start_page_token", new_start_page_token)
@@ -168,7 +199,7 @@ def run_pass1():
             new_start_page_token = None
 
             while active_token:
-                _touch_lease(state)
+                _touch_lease_or_raise(state, "Delta-Fetch")
                 log.debug("Delta Chunk", extra={"token": active_token})
                 changes, next_token, new_start = drive_mgr.fetch_delta_chunk(active_token)
                 files = [f for f in changes if f.get("mimeType") != "application/vnd.google-apps.folder"]

--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -431,6 +431,7 @@ def run_pass2():
 
     if not records_to_index:
         state.set_val("current_phase", "PASS2_DONE")
+        state.set_val("ready_for_pass2_run_id", "")
         state.flush_state()
         state.log_run("PASS_2", "NO_FILES", 0, errors)
         return

--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -10,6 +10,7 @@ from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
 from shared.sheets_helpers import SheetManager
 from shared.state_helpers import StateTracker
+from shared.drive_helpers import DriveManager
 from shared.gemini_helpers import GeminiOCR
 from shared.models import FileRecord
 from personal_brain.runtime import PersonalBrainRuntime
@@ -294,6 +295,7 @@ def run_pass2():
 
     sheet_mgr = SheetManager(sheets_service, CONTROL_SHEET_ID)
     state = StateTracker(sheet_mgr)
+    drive_mgr = DriveManager(drive_service, "", ENABLE_SHARED_DRIVES)
     log = get_logger("pass2", run_id=state.run_id, phase="PASS_2")
     log.info("Pass 2 gestartet")
     ocr = GeminiOCR(drive_service, ENABLE_SHARED_DRIVES)
@@ -303,10 +305,12 @@ def run_pass2():
 
     if not current_run_id:
         state.set_val("current_phase", "PASS2_BLOCKED_NO_HANDOVER")
+        state.flush_state()
         state.log_error("PASS_2", "SYSTEM", "", "NoRunID", "Keine explizite Pass 1 Übergabe (ready_for_pass2_run_id) gefunden.")
         return
 
     state.set_val("current_phase", "PASS2_OCR_INDEXING")
+    state.flush_state()
 
     # Load Knowledge Exclusions
     exclusions = {}
@@ -426,6 +430,8 @@ def run_pass2():
             processed += 1
 
     if not records_to_index:
+        state.set_val("current_phase", "PASS2_DONE")
+        state.flush_state()
         state.log_run("PASS_2", "NO_FILES", 0, errors)
         return
 
@@ -475,12 +481,14 @@ def run_pass2():
         media = MediaFileUpload(filename, mimetype="application/x-ndjson")
         params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
 
-        drive_service.files().create(
-            body={"name": filename, "parents": [INDEX_FOLDER_ID]},
-            media_body=media,
-            fields="id",
-            **params
-        ).execute()
+        def _upload_delta():
+            return drive_service.files().create(
+                body={"name": filename, "parents": [INDEX_FOLDER_ID]},
+                media_body=media,
+                fields="id",
+                **params
+            ).execute()
+        drive_mgr.execute_with_backoff(_upload_delta)
 
         BRAIN_INDEX_ROOT.mkdir(parents=True, exist_ok=True)
         runtime = PersonalBrainRuntime(project_id=PROJECT_SLUG, out_root=BRAIN_INDEX_ROOT)
@@ -492,10 +500,12 @@ def run_pass2():
         state.set_val("current_phase", "PASS2_DONE")
         # Clear coordination key indicating successful processing
         state.set_val("ready_for_pass2_run_id", "")
+        state.flush_state()
         state.log_run("PASS_2", "SUCCESS", processed, errors)
 
     except Exception as e:
         state.set_val("current_phase", "PASS2_FAILED")
+        state.flush_state()
         state.log_error("PASS_2", "SYSTEM", "ExportJSONL", "Fatal", str(e))
         state.log_run("PASS_2", "FAILED", processed, errors + 1)
         raise e

--- a/bummdidumm_os_v5_final_release/main_safe_sort.py
+++ b/bummdidumm_os_v5_final_release/main_safe_sort.py
@@ -106,8 +106,6 @@ def run_safe_sort():
             meta = known.get(file_id, {})
             if meta.get("parent_ids_sorted"):
                 current_parent_id = meta["parent_ids_sorted"].split(",")[0]
-            elif "/" in current_path:
-                current_parent_id = current_path.split("/", 1)[0]
 
             if not current_parent_id:
                 current_parent_id = "N/A"

--- a/bummdidumm_os_v5_final_release/shared/drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/drive_helpers.py
@@ -1,5 +1,4 @@
-from typing import List, Dict, Tuple, Optional
-from datetime import datetime, timezone
+from typing import List, Dict, Tuple, Optional, Callable
 from shared.log import get_logger as _get_logger
 _log = _get_logger("drive", phase="SHARED")
 
@@ -103,7 +102,14 @@ class DriveManager:
             "Use walk_recursive_chunked() for all production code paths."
         )
 
-    def walk_recursive_chunked(self, folder_id: str, state, process_batch_callback, batch_kwargs: dict):
+    def walk_recursive_chunked(
+        self,
+        folder_id: str,
+        state,
+        process_batch_callback,
+        batch_kwargs: dict,
+        lease_touch_callback: Optional[Callable[[], None]] = None,
+    ):
         """Performs initial recursive scan in bounded chunks to prevent timeout endloops."""
         queue = state.get_val("initial_scan_queue")
         if queue:
@@ -154,11 +160,11 @@ class DriveManager:
                 # Checkpointing
                 state.set_val("initial_scan_queue", ",".join(queue))
                 state.set_val("initial_scan_page_token", page_token or "")
-                if state.get_val("lease_owner_id"):
-                    state.set_val("lease_heartbeat_at", datetime.now(timezone.utc).isoformat())
                 # We do not strictly need to save the new start token here as it's fetched at the start of walk
                 # but if we wanted to, we could. The queue saves the progress anyway.
                 state.flush_state()
+                if lease_touch_callback:
+                    lease_touch_callback()
 
                 if not page_token:
                     break

--- a/bummdidumm_os_v5_final_release/shared/drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/drive_helpers.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Tuple, Optional
+from datetime import datetime, timezone
 from shared.log import get_logger as _get_logger
 _log = _get_logger("drive", phase="SHARED")
 
@@ -83,8 +84,6 @@ class DriveManager:
 
     def get_initial_token(self) -> str:
         params = self._base_params()
-        if self.enable_shared_drives:
-            params["driveId"] = None
         res = self.drive.changes().getStartPageToken(**params).execute()
         return res.get("startPageToken")
 
@@ -155,6 +154,8 @@ class DriveManager:
                 # Checkpointing
                 state.set_val("initial_scan_queue", ",".join(queue))
                 state.set_val("initial_scan_page_token", page_token or "")
+                if state.get_val("lease_owner_id"):
+                    state.set_val("lease_heartbeat_at", datetime.now(timezone.utc).isoformat())
                 # We do not strictly need to save the new start token here as it's fetched at the start of walk
                 # but if we wanted to, we could. The queue saves the progress anyway.
                 state.flush_state()
@@ -175,7 +176,9 @@ class DriveManager:
         params["spaces"] = "drive"
         params["fields"] = "nextPageToken, newStartPageToken, changes(fileId, removed, file(id,name,mimeType,size,md5Checksum,parents,createdTime,modifiedTime,trashed,webViewLink,description,starred,owners(emailAddress,displayName),lastModifyingUser(emailAddress,displayName),capabilities(canEdit,canShare,canDownload)))"
 
-        res = self.drive.changes().list(**params).execute()
+        def _do_delta_list():
+            return self.drive.changes().list(**params).execute()
+        res = self.execute_with_backoff(_do_delta_list)
 
         changes = []
         for change in res.get("changes", []):

--- a/bummdidumm_os_v5_final_release/shared/sheets_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/sheets_helpers.py
@@ -77,6 +77,7 @@ class SheetManager:
                     ))
         except Exception as e:
             _log.error("Sheets init fehlgeschlagen", extra={"error": str(e)})
+            raise
 
     def append_rows(self, tab: str, rows: List[List[Any]]):
         if not rows:

--- a/bummdidumm_os_v5_final_release/shared/state_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/state_helpers.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import os
+import uuid
 from typing import Dict, List, Optional, Any
 from .sheets_helpers import SheetManager
 from .models import FileRecord
@@ -9,7 +10,10 @@ _log = _get_logger("state", phase="SHARED")
 class StateTracker:
     def __init__(self, sheets_manager: SheetManager):
         self.sheets = sheets_manager
-        self.run_id = f"run_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        uniq = uuid.uuid4().hex[:8]
+        self.run_id = f"run_{ts}_{uniq}"
+        self.owner_id = f"owner_{uuid.uuid4().hex}"
 
         self._state_cache: dict[str, str] = {}
         self._known_hashes: Optional[Dict[str, dict[str, Any]]] = None
@@ -18,23 +22,15 @@ class StateTracker:
         self.sheets.initialize_headers()
         self._load_state()
 
-        # Resume-Verhalten absichern:
-        # Falls wir uns noch in einem laufenden Lauf befinden, behalten wir die run_id,
-        # anstatt einen neuen Report-Block anzufangen.
-        current_phase = self._state_cache.get("current_phase", "IDLE")
-        saved_run_id = self._state_cache.get("run_id")
-        if current_phase in ["DELTA_FETCH", "INITIAL_SCAN"] and saved_run_id:
-            self.run_id = saved_run_id
-        else:
-            # Speichere die neue run_id
-            self.set_val("run_id", self.run_id)
-            self.flush_state()
-
     def _load_state(self):
+        self._state_cache = {}
         rows = self.sheets.read_all_rows("State", "A:B")
         for row in rows:
             if len(row) >= 2 and row[0] != "key":
                 self._state_cache[row[0]] = row[1]
+
+    def reload_state(self):
+        self._load_state()
 
     def get_val(self, key: str) -> Optional[str]:
         return self._state_cache.get(key)

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_drive_helpers.py
@@ -6,9 +6,7 @@ Covers:
 """
 import sys
 import os
-import time
-import types
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 from shared.drive_helpers import DriveManager

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_drive_helpers.py
@@ -137,3 +137,18 @@ class TestExecuteWithBackoff:
 
         with pytest.raises(HttpError):
             mgr.execute_with_backoff(forbidden)
+
+
+class TestFetchDeltaChunk:
+    def test_fetch_delta_chunk_uses_backoff_wrapper(self):
+        mgr = _make_manager()
+        mgr.execute_with_backoff = MagicMock(
+            return_value={"changes": [], "nextPageToken": "nxt", "newStartPageToken": "new"}
+        )
+
+        changes, next_token, new_start = mgr.fetch_delta_chunk("token_1")
+
+        assert changes == []
+        assert next_token == "nxt"
+        assert new_start == "new"
+        assert mgr.execute_with_backoff.call_count == 1

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_gemini_helpers.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_gemini_helpers.py
@@ -9,7 +9,7 @@ Covers:
 import sys
 import os
 import tempfile
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 from shared.gemini_helpers import GeminiOCR

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
@@ -6,9 +6,11 @@ class DummyStateTracker:
     def __init__(self, initial_state):
         self._state = initial_state
         self.run_id = "run_new"
+        self.owner_id = "owner_new"
     def get_val(self, key): return self._state.get(key)
     def set_val(self, key, val): self._state[key] = val
     def flush_state(self): pass
+    def reload_state(self): pass
     def load_known_hashes(self): return {}
 
 class DummySheetMgr:
@@ -46,7 +48,13 @@ class TestParallelRunGuard(unittest.TestCase):
 
     def test_active_run_prevented(self):
         recent_time = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
-        state = DummyStateTracker({"current_phase": "DELTA_FETCH", "run_id": "run_active", "last_run_utc": recent_time})
+        state = DummyStateTracker({
+            "current_phase": "DELTA_FETCH",
+            "run_id": "run_active",
+            "last_run_utc": recent_time,
+            "lease_owner_id": "owner_active",
+            "lease_heartbeat_at": recent_time
+        })
 
         import main_pass1
         old_creds = main_pass1.get_user_credentials

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
@@ -1,78 +1,156 @@
 import unittest
-from main_pass1 import run_pass1
 from datetime import datetime, timezone, timedelta
+from unittest import mock
+
+import main_pass1
+from main_pass1 import _acquire_lease_or_abort, run_pass1
+
+
+class SharedStateStore:
+    def __init__(self, initial: dict):
+        self.data = dict(initial)
+
 
 class DummyStateTracker:
-    def __init__(self, initial_state):
-        self._state = initial_state
-        self.run_id = "run_new"
-        self.owner_id = "owner_new"
-    def get_val(self, key): return self._state.get(key)
-    def set_val(self, key, val): self._state[key] = val
-    def flush_state(self): pass
-    def reload_state(self): pass
-    def load_known_hashes(self): return {}
+    def __init__(self, shared_store: SharedStateStore, owner_id: str, run_id: str, force_lose_after_flush: bool = False):
+        self._shared = shared_store
+        self._state = dict(shared_store.data)
+        self.owner_id = owner_id
+        self.run_id = run_id
+        self.force_lose_after_flush = force_lose_after_flush
 
-class DummySheetMgr:
-    def read_all_rows(self, *args): return []
+    def get_val(self, key):
+        return self._state.get(key)
 
-class TestParallelRunGuard(unittest.TestCase):
-    def test_stale_run_overridden(self):
-        old_time = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
-        state = DummyStateTracker({"current_phase": "INITIAL_SCAN", "run_id": "run_old", "last_run_utc": old_time})
+    def set_val(self, key, val):
+        self._state[key] = val
 
-        # Test requires mocking drive_service and drive_mgr in run_pass1.
-        # But we can just test the guard logic explicitly if we extracted it, or we mock the module.
-        import main_pass1
+    def flush_state(self):
+        self._shared.data = dict(self._state)
+        if self.force_lose_after_flush:
+            self._shared.data["lease_owner_id"] = "owner_other_won"
+
+    def reload_state(self):
+        self._state = dict(self._shared.data)
+
+    def load_known_hashes(self):
+        return {}
+
+    def compact_hash_index(self):
+        pass
+
+    def compact_reports(self):
+        pass
+
+    def log_run(self, *args, **kwargs):
+        pass
+
+    def log_error(self, *args, **kwargs):
+        pass
+
+
+class TestParallelRunGuardHelpers(unittest.TestCase):
+    def test_active_foreign_lease_blocks_even_when_phase_idle(self):
+        recent = datetime.now(timezone.utc).isoformat()
+        shared = SharedStateStore(
+            {
+                "current_phase": "IDLE",
+                "lease_owner_id": "owner_a",
+                "lease_heartbeat_at": recent,
+                "run_id": "run_a",
+            }
+        )
+        state = DummyStateTracker(shared, owner_id="owner_b", run_id="run_b")
+        log = mock.Mock()
+
+        self.assertFalse(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
+
+    def test_stale_lease_can_be_taken_over(self):
+        stale = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        shared = SharedStateStore(
+            {
+                "current_phase": "WHATEVER",
+                "lease_owner_id": "owner_old",
+                "lease_heartbeat_at": stale,
+                "run_id": "run_old",
+            }
+        )
+        state = DummyStateTracker(shared, owner_id="owner_new", run_id="run_new")
+        log = mock.Mock()
+
+        self.assertTrue(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
+        self.assertEqual(shared.data.get("lease_owner_id"), "owner_new")
+        self.assertEqual(shared.data.get("run_id"), "run_new")
+
+    def test_same_owner_can_continue(self):
+        recent = datetime.now(timezone.utc).isoformat()
+        shared = SharedStateStore(
+            {
+                "lease_owner_id": "owner_same",
+                "lease_heartbeat_at": recent,
+                "run_id": "run_prev",
+            }
+        )
+        state = DummyStateTracker(shared, owner_id="owner_same", run_id="run_new")
+        log = mock.Mock()
+
+        self.assertTrue(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
+        self.assertEqual(shared.data.get("lease_owner_id"), "owner_same")
+
+    def test_second_instance_loses_after_reload_verification(self):
+        shared = SharedStateStore({})
+        state = DummyStateTracker(
+            shared,
+            owner_id="owner_candidate",
+            run_id="run_candidate",
+            force_lose_after_flush=True,
+        )
+        log = mock.Mock()
+
+        self.assertFalse(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
+        self.assertEqual(shared.data.get("lease_owner_id"), "owner_other_won")
+
+
+class TestParallelRunGuardIntegration(unittest.TestCase):
+    def test_pre_phase_foreign_lease_blocks_run_start(self):
+        recent = datetime.now(timezone.utc).isoformat()
+        shared = SharedStateStore(
+            {
+                "current_phase": "IDLE",
+                "lease_owner_id": "owner_instance_a",
+                "lease_heartbeat_at": recent,
+                "run_id": "run_instance_a",
+            }
+        )
+        state_b = DummyStateTracker(shared, owner_id="owner_instance_b", run_id="run_instance_b")
+
         old_creds = main_pass1.get_user_credentials
         old_build = main_pass1.build
+        old_state_tracker = main_pass1.StateTracker
+        old_sheet_mgr = main_pass1.SheetManager
         old_drive_mgr = main_pass1.DriveManager
-        old_state_tracker = main_pass1.StateTracker
+        old_control_sheet = main_pass1.CONTROL_SHEET_ID
 
         main_pass1.get_user_credentials = lambda: None
-        main_pass1.build = lambda *args, **kwargs: None
-        main_pass1.DriveManager = lambda *args, **kwargs: mock.Mock()
-        main_pass1.StateTracker = lambda *args, **kwargs: state
-        main_pass1.CONTROL_SHEET_ID = "123"
-        import unittest.mock as mock
-
-        try:
-            # Running this should not return early, meaning it overtakes the old run and hits the walk error or completes
-            with self.assertRaises(AttributeError): # It hits drive_mgr.walk_recursive_chunked which we mocked badly, but it PASSED the guard!
-                run_pass1()
-        finally:
-            main_pass1.get_user_credentials = old_creds
-            main_pass1.build = old_build
-            main_pass1.DriveManager = old_drive_mgr
-            main_pass1.StateTracker = old_state_tracker
-
-    def test_active_run_prevented(self):
-        recent_time = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
-        state = DummyStateTracker({
-            "current_phase": "DELTA_FETCH",
-            "run_id": "run_active",
-            "last_run_utc": recent_time,
-            "lease_owner_id": "owner_active",
-            "lease_heartbeat_at": recent_time
-        })
-
-        import main_pass1
-        old_creds = main_pass1.get_user_credentials
-        old_build = main_pass1.build
-        old_state_tracker = main_pass1.StateTracker
-
-        main_pass1.get_user_credentials = lambda: None
-        main_pass1.build = lambda *args, **kwargs: None
-        main_pass1.StateTracker = lambda *args, **kwargs: state
+        main_pass1.build = lambda *args, **kwargs: object()
+        main_pass1.SheetManager = lambda *args, **kwargs: mock.Mock()
+        main_pass1.StateTracker = lambda *args, **kwargs: state_b
+        mocked_drive_mgr = mock.Mock()
+        main_pass1.DriveManager = lambda *args, **kwargs: mocked_drive_mgr
         main_pass1.CONTROL_SHEET_ID = "123"
 
         try:
-            # This should return immediately and gracefully (None)
             self.assertIsNone(run_pass1())
+            mocked_drive_mgr.walk_recursive_chunked.assert_not_called()
+            mocked_drive_mgr.fetch_delta_chunk.assert_not_called()
         finally:
             main_pass1.get_user_credentials = old_creds
             main_pass1.build = old_build
             main_pass1.StateTracker = old_state_tracker
+            main_pass1.SheetManager = old_sheet_mgr
+            main_pass1.DriveManager = old_drive_mgr
+            main_pass1.CONTROL_SHEET_ID = old_control_sheet
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 from unittest import mock
 
 import main_pass1
-from main_pass1 import _acquire_lease_or_abort, run_pass1
+from main_pass1 import _acquire_lease_or_abort, _touch_lease, run_pass1
 
 
 class SharedStateStore:
@@ -80,7 +80,8 @@ class TestParallelRunGuardHelpers(unittest.TestCase):
 
         self.assertTrue(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
         self.assertEqual(shared.data.get("lease_owner_id"), "owner_new")
-        self.assertEqual(shared.data.get("run_id"), "run_new")
+        self.assertEqual(shared.data.get("run_id"), "run_old")
+        self.assertEqual(state.run_id, "run_old")
 
     def test_same_owner_can_continue(self):
         recent = datetime.now(timezone.utc).isoformat()
@@ -109,6 +110,37 @@ class TestParallelRunGuardHelpers(unittest.TestCase):
 
         self.assertFalse(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
         self.assertEqual(shared.data.get("lease_owner_id"), "owner_other_won")
+
+    def test_touch_lease_does_not_overwrite_foreign_owner(self):
+        shared = SharedStateStore(
+            {
+                "lease_owner_id": "owner_foreign",
+                "lease_heartbeat_at": "2026-01-01T00:00:00+00:00",
+                "run_id": "run_foreign",
+            }
+        )
+        state = DummyStateTracker(shared, owner_id="owner_local", run_id="run_local")
+
+        result = _touch_lease(state)
+
+        self.assertFalse(result)
+        self.assertEqual(shared.data.get("lease_owner_id"), "owner_foreign")
+        self.assertEqual(shared.data.get("run_id"), "run_foreign")
+
+    def test_resume_without_lease_adopts_existing_run_id(self):
+        shared = SharedStateStore(
+            {
+                "current_phase": "DELTA_FETCH",
+                "lease_owner_id": "",
+                "run_id": "run_resume_001",
+            }
+        )
+        state = DummyStateTracker(shared, owner_id="owner_resume", run_id="run_new")
+        log = mock.Mock()
+
+        self.assertTrue(_acquire_lease_or_abort(state, log, lease_timeout_sec=3600))
+        self.assertEqual(state.run_id, "run_resume_001")
+        self.assertEqual(shared.data.get("run_id"), "run_resume_001")
 
 
 class TestParallelRunGuardIntegration(unittest.TestCase):

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_state_helpers.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_state_helpers.py
@@ -8,7 +8,7 @@ Covers:
 """
 import sys
 import os
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 from shared.state_helpers import StateTracker


### PR DESCRIPTION
### Motivation

- Close a real concurrency/corruption window where two instances could resume with the same `run_id` and proceed in parallel, and make run identification robust against same-second collisions.  
- Ensure state transitions that matter for orchestration (handover flags and phase changes) are durably persisted before any early return/crash-prone work.  
- Make the Drive incremental path and Pass 2 upload resilient to transient API errors via the existing backoff logic.  

### Description

- Replace the fragile `run_id`-equality guard with a lease model: each `StateTracker` now has an `owner_id` and Pass 1 acquires `lease_owner_id` + `lease_heartbeat_at` and uses a TTL (`RUN_LEASE_TIMEOUT_SEC`) to decide stale leases; re-read (`reload_state`) verifies acquisition.  
- Improve uniqueness of `run_id` by appending a short UUID suffix and add `owner_id` generation in `StateTracker`.  
- Add explicit `flush_state()` calls at early-return and phase-change locations in `main_pass2.py`, `main_apply_sort.py`, and `main_apply_renames.py` so `current_phase`, `ready_for_pass2_run_id` and similar keys are persisted before risky operations or returns.  
- Use the Drive backoff wrapper for delta listing and for Pass 2 JSONL uploads by routing `changes().list()` and `files().create()` through `DriveManager.execute_with_backoff()`.  
- Remove the unsafe fallback that derived `current_parent_id` from display-path strings in `main_safe_sort.py` so false parent IDs are not invented.  
- Make `SheetManager.initialize_headers()` fail-fast by re-raising initialization errors instead of only logging them.  
- Adjusted the parallel-run guard smoke test doubles to include `owner_id`, `lease_owner_id`, `lease_heartbeat_at`, and `reload_state()` semantics.  

### Testing

- Ran the focused smoke tests with `pytest -q tests/smoke/test_state_helpers.py tests/smoke/test_drive_helpers.py tests/smoke/test_parallel_run_guard.py tests/smoke/test_apply_renames_chunking.py` and the suite passed (`27 passed`, `1 warning`).  
- The modified `test_parallel_run_guard.py` was updated to exercise the new lease-based guard and validates both takeover and active-run prevention scenarios.  
- No live Drive/Sheets/Cloud runs were executed in this change; the fixes target deterministic logic and API retry wiring validated by the unit tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df89e7d018832d9c2ee8c06f436c63)