### PR TITLE
Fix critical state persistence and race condition bugs in Pass1 and Brain indexing

### DIFF
--- a/bummdidumm_os_v5_final_release/main_apply_renames.py
+++ b/bummdidumm_os_v5_final_release/main_apply_renames.py
@@ -38,32 +38,66 @@ def run_apply_renames():
 
     processed = 0
     errors = 0
+    update_requests = []
 
-    for chunk in sheet_mgr.read_rows_chunked("Dedupe_Report", chunk_size=1000):
-        for row in chunk:
-            if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) or row[0] == "run_utc":
-                continue
-            if row[sheet_mgr.DEDUPE_COL["run_id"]] != current_run_id:
-                continue
+    rename_result_col = sheet_mgr.DEDUPE_COL.get("rename_result", 17)
+    col_letter = chr(ord("A") + rename_result_col)  # "R" for index 17
 
-            file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
-            current_name = row[sheet_mgr.DEDUPE_COL["name"]]
-            suggested_name = row[sheet_mgr.DEDUPE_COL["suggested_name"]]
+    for row_idx, row in sheet_mgr.read_rows_chunked_with_row_numbers("Dedupe_Report", chunk_size=1000):
+        if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) - 1 or row[0] == "run_utc":
+            continue
+        if row[sheet_mgr.DEDUPE_COL["run_id"]] != current_run_id:
+            continue
 
-            if suggested_name and suggested_name != current_name:
-                try:
-                    params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
-                    def _update_name():
-                        return drive_service.files().update(
-                            fileId=file_id,
-                            body={"name": suggested_name},
-                            **params
-                        ).execute()
-                    drive_mgr.execute_with_backoff(_update_name)
-                    processed += 1
-                except Exception as e:
-                    errors += 1
-                    state.log_error("RENAME", file_id, current_name, "UpdateError", str(e))
+        # RISK-3 fix: idempotency guard — skip rows already successfully renamed
+        existing_rename_result = row[rename_result_col] if len(row) > rename_result_col else ""
+        if existing_rename_result == "SUCCESS":
+            continue
+
+        file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
+        current_name = row[sheet_mgr.DEDUPE_COL["name"]]
+        suggested_name = row[sheet_mgr.DEDUPE_COL["suggested_name"]]
+
+        if suggested_name and suggested_name != current_name:
+            result_val = None
+            try:
+                params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
+                def _update_name():
+                    return drive_service.files().update(
+                        fileId=file_id,
+                        body={"name": suggested_name},
+                        **params
+                    ).execute()
+                drive_mgr.execute_with_backoff(_update_name)
+                result_val = "SUCCESS"
+                processed += 1
+            except Exception as e:
+                errors += 1
+                result_val = f"FAILED: {str(e)[:80]}"
+                state.log_error("RENAME", file_id, current_name, "UpdateError", str(e))
+
+            update_requests.append({
+                "range": f"Dedupe_Report!{col_letter}{row_idx}",
+                "values": [[result_val]]
+            })
+
+            # Flush periodically to bound memory
+            if len(update_requests) >= 50:
+                def _batch():
+                    return sheets_service.spreadsheets().values().batchUpdate(
+                        spreadsheetId=CONTROL_SHEET_ID,
+                        body={"valueInputOption": "RAW", "data": update_requests}
+                    ).execute()
+                sheet_mgr._execute_with_backoff(_batch())
+                update_requests = []
+
+    if update_requests:
+        def _batch_final():
+            return sheets_service.spreadsheets().values().batchUpdate(
+                spreadsheetId=CONTROL_SHEET_ID,
+                body={"valueInputOption": "RAW", "data": update_requests}
+            ).execute()
+        sheet_mgr._execute_with_backoff(_batch_final())
 
     state.log_run("RENAME", "SUCCESS", processed, errors)
     state.set_val("current_phase", "IDLE")

--- a/bummdidumm_os_v5_final_release/main_apply_renames.py
+++ b/bummdidumm_os_v5_final_release/main_apply_renames.py
@@ -41,7 +41,16 @@ def run_apply_renames():
     update_requests = []
 
     rename_result_col = sheet_mgr.DEDUPE_COL.get("rename_result", 17)
-    col_letter = chr(ord("A") + rename_result_col)  # "R" for index 17
+
+    def _col_letter(n: int) -> str:
+        """Convert 0-based column index to Sheets A1 column letter (handles AA, AB, …)."""
+        res = ""
+        while n >= 0:
+            res = chr(ord("A") + (n % 26)) + res
+            n = (n // 26) - 1
+        return res
+
+    col_letter = _col_letter(rename_result_col)
 
     for row_idx, row in sheet_mgr.read_rows_chunked_with_row_numbers("Dedupe_Report", chunk_size=1000):
         if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) - 1 or row[0] == "run_utc":

--- a/bummdidumm_os_v5_final_release/main_apply_sort.py
+++ b/bummdidumm_os_v5_final_release/main_apply_sort.py
@@ -65,19 +65,20 @@ def run_apply_sort():
                     drive_mgr.execute_with_backoff(_trash)
                     result_val = "SUCCESS_TRASHED"
                 else:
-                    def _get_parents():
-                        return drive_service.files().get(fileId=file_id, fields="parents", **params).execute()
-                    file_meta = drive_mgr.execute_with_backoff(_get_parents)
-                    previous_parents = ",".join(file_meta.get("parents", []))
-
-                    def _update_parents():
+                    # M-3 fix: fetch parents inside the retry closure so each retry uses
+                    # fresh parent data rather than a value captured before the first attempt.
+                    def _move_file():
+                        meta = drive_service.files().get(
+                            fileId=file_id, fields="parents", **params
+                        ).execute()
+                        prev = ",".join(meta.get("parents", []))
                         return drive_service.files().update(
                             fileId=file_id,
                             addParents=target_folder_id,
-                            removeParents=previous_parents,
+                            removeParents=prev,
                             **params
                         ).execute()
-                    drive_mgr.execute_with_backoff(_update_parents)
+                    drive_mgr.execute_with_backoff(_move_file)
                     result_val = "SUCCESS"
 
                 processed += 1

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -238,10 +238,10 @@ def run_pass1():
         state.set_val("ready_for_pass2_run_id", state.run_id)
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
         state.flush_state()       # BUG-1 fix: persist before reload_state() inside _release_lease
+        state.compact_hash_index()  # compact while lease is still held to prevent race on clear+update
+        state.compact_reports()
         _release_lease(state)
         state.flush_state()       # persist lease release (owner_id="")
-        state.compact_hash_index()
-        state.compact_reports()
         state.log_run("PASS_1", "SUCCESS", processed, errors)
 
     except Exception as e:

--- a/bummdidumm_os_v5_final_release/main_pass1.py
+++ b/bummdidumm_os_v5_final_release/main_pass1.py
@@ -1,4 +1,5 @@
 import os
+import time
 from shared.oauth_user_credentials import get_user_credentials
 from googleapiclient.discovery import build
 from datetime import datetime, timezone
@@ -43,7 +44,7 @@ def _is_lease_stale(state, lease_timeout_sec: int) -> bool:
         return False
     try:
         last_t = datetime.fromisoformat(heartbeat_utc_str)
-    except ValueError:
+    except (ValueError, TypeError):  # M-1 fix: fromisoformat raises TypeError on non-string input
         return False
     diff = (datetime.now(timezone.utc) - last_t).total_seconds()
     return diff >= lease_timeout_sec
@@ -108,6 +109,7 @@ def _acquire_lease_or_abort(state, log, lease_timeout_sec: int) -> bool:
         state.run_id = existing_run_id
 
     _claim_lease(state)
+    time.sleep(0.5)  # RISK-1 fix: 500ms fence reduces TOCTOU window before verification read
     state.reload_state()
     if state.get_val("lease_owner_id") != state.owner_id:
         log.warning("Parallel-Run Guard: Lease-Konkurrenz erkannt, Start abgebrochen.")
@@ -227,6 +229,7 @@ def run_pass1():
             if new_start_page_token:
                 state.set_val("drive_start_page_token", new_start_page_token)
                 state.set_val("in_progress_page_token", "")
+                state.flush_state()  # BUG-2 fix: checkpoint token advancement before success block
 
         state.set_val("current_phase", "PASS1_DONE")
         state.set_val("last_successful_run_id", state.run_id)
@@ -234,8 +237,9 @@ def run_pass1():
         # Pass 2 should only pick up this run_id when explicitly signaled.
         state.set_val("ready_for_pass2_run_id", state.run_id)
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
+        state.flush_state()       # BUG-1 fix: persist before reload_state() inside _release_lease
         _release_lease(state)
-        state.flush_state()
+        state.flush_state()       # persist lease release (owner_id="")
         state.compact_hash_index()
         state.compact_reports()
         state.log_run("PASS_1", "SUCCESS", processed, errors)
@@ -243,8 +247,9 @@ def run_pass1():
     except Exception as e:
         state.set_val("current_phase", "PASS1_FAILED")
         state.set_val("last_run_utc", datetime.now(timezone.utc).isoformat())
+        state.flush_state()       # BUG-1 fix: persist before reload_state() inside _release_lease
         _release_lease(state)
-        state.flush_state()
+        state.flush_state()       # persist lease release
         state.log_error("PASS_1", "SYSTEM", "", "Fatal", str(e))
         state.log_run("PASS_1", "FAILED", processed, errors + 1)
         raise e
@@ -281,7 +286,7 @@ def _build_file_record(f: dict, drive_mgr, known_file_details: dict, is_initial:
     change_type = determine_change_type(f, known_file_details, is_initial)
     suggested_name = (
         suggest_rename(name, f.get("createdTime", ""))
-        if change_type not in ["REMOVED_OR_NO_ACCESS", "TRASHED", "DELETED"]
+        if change_type not in ["REMOVED_OR_NO_ACCESS", "TRASHED", "DELETED", "MOVED_OUT_OF_SCOPE"]
         else ""
     )
 
@@ -417,6 +422,10 @@ def _process_file_batch(
             rec.status = "ORIGINAL_RESUMED" if duplicate_of_id == rec.file_id else "DUPLICATE"
             if rec.status == "DUPLICATE":
                 rec.duplicate_of = duplicate_of_id
+            else:
+                # DM-3 fix: ORIGINAL_RESUMED must refresh its cache entry so subsequent
+                # delta runs detect metadata changes (name, path, updated_at) correctly.
+                known_file_details[rec.file_id] = _make_cache_entry(rec)
         else:
             rec.status = "ORIGINAL"
             sha_to_primary_file_id[rec.sha256] = rec.file_id
@@ -444,7 +453,7 @@ def _process_file_batch(
         )
         change_type = rec.change_type
 
-        if change_type in ["REMOVED_OR_NO_ACCESS", "TRASHED", "DELETED"]:
+        if change_type in ["REMOVED_OR_NO_ACCESS", "TRASHED", "DELETED", "MOVED_OUT_OF_SCOPE"]:
             _handle_removed(rec)
         elif change_type == "UNCHANGED_CONTENT_METADATA_ONLY" or (
             not is_initial and check_md5_size_prefilter(f, known_file_details)

--- a/bummdidumm_os_v5_final_release/main_safe_sort.py
+++ b/bummdidumm_os_v5_final_release/main_safe_sort.py
@@ -91,12 +91,21 @@ def run_safe_sort():
     processed = 0
     errors = 0
 
+    # DM-2 fix: load already-written suggestions for this run to prevent duplicates
+    # when safe_sort is restarted mid-run (crash recovery).
+    existing_suggestion_file_ids: set = set()
+    for ex_row in sheet_mgr.read_all_rows("Sorting_Suggestions", "A:B"):
+        if len(ex_row) >= 2 and ex_row[0] == current_run_id:
+            existing_suggestion_file_ids.add(ex_row[1])
+
     for chunk_rows in sheet_mgr.read_rows_chunked("Dedupe_Report", chunk_size=1000):
         for row in chunk_rows:
             if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) or row[0] == "run_utc" or row[1] != current_run_id:
                 continue
 
             file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
+            if file_id in existing_suggestion_file_ids:
+                continue  # DM-2 fix: already suggested for this run
             name = row[sheet_mgr.DEDUPE_COL["name"]]
             mime_type = row[sheet_mgr.DEDUPE_COL["mime_type"]]
             status = row[sheet_mgr.DEDUPE_COL["status"]]

--- a/bummdidumm_os_v5_final_release/personal_brain/runtime.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/runtime.py
@@ -19,6 +19,12 @@ class PersonalBrainRuntime:
     def process_sources(self, sources: list[dict[str, Any]], exclusions: dict | None = None) -> dict[str, int]:
         if exclusions is None:
             exclusions = {}
+        # BUG-4 fix: collect file_ids whose Brain-index entries must be tombstone-deleted.
+        # PURGED sources are skipped below (continue), so they never appear in source_rows.
+        # Without this set the old JSONL entries stream through _write_jsonl unchanged.
+        purged_file_ids: set[str] = {
+            fid for fid, status in exclusions.items() if status == "PURGED"
+        }
         source_rows: dict[str, dict] = {}
         record_rows: dict[str, dict] = {}
         entity_rows: dict[str, dict] = {}
@@ -87,7 +93,10 @@ class PersonalBrainRuntime:
         entity_list = list(entity_rows.values())
         relation_list = list(relation_rows.values())
 
-        self.writer.write_source_record_entity_relation(source_list, record_list, entity_list, relation_list)
+        self.writer.write_source_record_entity_relation(
+            source_list, record_list, entity_list, relation_list,
+            purged_file_ids=purged_file_ids,
+        )
         self.writer.write_daily_memory(record_list)
         self.writer.write_weekly_memory(record_list)
         views = self.writer.write_search_views(record_list)

--- a/bummdidumm_os_v5_final_release/personal_brain/writers.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/writers.py
@@ -116,12 +116,15 @@ class JsonlWriter:
     # Write helpers
     # ------------------------------------------------------------------
 
-    def _write_jsonl(self, path: Path, rows: list[dict], key: str) -> None:
+    def _write_jsonl(self, path: Path, rows: list[dict], key: str, purged_file_ids: set | None = None) -> None:
         """Streaming-Merge-Write: new rows overwrite existing rows by stable ID.
 
         Existing rows absent from `rows` are streamed directly to the temp file
         without being buffered in RAM. Only the incoming `rows` (O(m)) are held
         in memory, avoiding the previous O(n) full-load for large indices.
+
+        purged_file_ids: if provided, existing rows whose ``file_id`` field is in
+        this set are tombstone-deleted (BUG-4 fix for PURGED sources persisting).
         """
         path.parent.mkdir(parents=True, exist_ok=True)
         new_lookup = {row[key]: row for row in rows}
@@ -146,6 +149,8 @@ class JsonlWriter:
                             row = json.loads(stripped)
                             k = row.get(key)
                             if k not in new_lookup:
+                                if purged_file_ids and row.get("file_id") in purged_file_ids:
+                                    continue  # BUG-4 fix: tombstone-delete PURGED entry
                                 out.write(stripped + "\n")
                         except Exception as e:
                             _log.warning(
@@ -222,9 +227,11 @@ class JsonlWriter:
         records: list[dict],
         entities: list[dict],
         relations: list[dict],
+        purged_file_ids: set | None = None,
     ) -> None:
-        self._write_jsonl(self.published / "00_source_registry.jsonl", sources, "source_id")
-        self._write_jsonl(self.published / "01_record_index.jsonl", records, "record_id")
+        pf = purged_file_ids or set()
+        self._write_jsonl(self.published / "00_source_registry.jsonl", sources, "source_id", purged_file_ids=pf)
+        self._write_jsonl(self.published / "01_record_index.jsonl", records, "record_id", purged_file_ids=pf)
 
         # Custom merge logic for entities — single-pass streaming to keep RAM at O(m).
         # Existing entities that match an incoming entity_id are merged in place and

--- a/bummdidumm_os_v5_final_release/shared/change_type_logic.py
+++ b/bummdidumm_os_v5_final_release/shared/change_type_logic.py
@@ -18,6 +18,11 @@ def determine_change_type(f: dict, known_file_details: dict, is_initial: bool) -
     if trashed:
         return "TRASHED"
 
+    # 3a. MOVED_OUT_OF_SCOPE: file exists in Drive but was moved outside the target folder tree.
+    # Synthetic flag set by fetch_delta_chunk() when is_in_target_folder() returns False.
+    if removed and f.get("scope_exit"):
+        return "MOVED_OUT_OF_SCOPE"
+
     # 3. REMOVED_OR_NO_ACCESS
     # Removed true but not explicitly deleted (e.g., access revoked)
     if removed:

--- a/bummdidumm_os_v5_final_release/shared/drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/drive_helpers.py
@@ -218,6 +218,13 @@ class DriveManager:
                 if f.get("parents") and self.is_in_target_folder(f["id"], f["parents"]):
                     f["removed"] = False
                     changes.append(f)
+            else:
+                # BUG-3 fix: file exists in Drive but has moved outside the target folder tree.
+                # Without this branch the change was silently dropped, leaving Hash_Index and
+                # Dedupe_Report permanently stale for this file.
+                f["removed"] = True
+                f["scope_exit"] = True
+                changes.append(f)
 
         return changes, res.get("nextPageToken"), res.get("newStartPageToken")
 

--- a/bummdidumm_os_v5_final_release/shared/sheets_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/sheets_helpers.py
@@ -13,7 +13,7 @@ class SheetManager:
         self.headers = {
             "State": ["key", "value"],
             "Hash_Index": ["sha256", "file_id", "name", "parent_ids_sorted", "path_display", "updated_at", "size_bytes", "md5", "effective_mime_type"],
-            "Dedupe_Report": ["run_utc", "run_id", "path", "name", "file_id", "mime_type", "effective_mime_type", "size_bytes", "md5", "sha256", "status", "change_type", "duplicate_of", "archive_result", "suggested_name", "web_link", "notes"],
+            "Dedupe_Report": ["run_utc", "run_id", "path", "name", "file_id", "mime_type", "effective_mime_type", "size_bytes", "md5", "sha256", "status", "change_type", "duplicate_of", "archive_result", "suggested_name", "web_link", "notes", "rename_result"],
             "Duplicate_Groups": ["sha256", "original_file_id", "duplicate_file_ids", "count"],
             "Error_Report": ["run_utc", "run_id", "phase", "file_id", "path", "error_type", "error_message"],
             "Run_Log": ["run_utc", "run_id", "phase", "status", "files_processed", "errors"],

--- a/bummdidumm_os_v5_final_release/shared/state_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/state_helpers.py
@@ -96,7 +96,10 @@ class StateTracker:
             compacted = ([header] if header else []) + keep
             _log.info(f"{sheet_name} Kompaktierung gestartet",
                       extra={"before": len(rows), "after": len(compacted)})
-            # Clear first to avoid stale trailing rows, then rewrite
+            # RISK-4 fix: buffer locally so we can restore if update fails after clear
+            buffered_compacted = list(compacted)
+            original_rows = list(rows)
+
             self.sheets._execute_with_backoff(
                 self.sheets.sheets.spreadsheets().values().clear(
                     spreadsheetId=self.sheets.spreadsheet_id,
@@ -104,14 +107,37 @@ class StateTracker:
                     body={}
                 )
             )
-            self.sheets._execute_with_backoff(
-                self.sheets.sheets.spreadsheets().values().update(
-                    spreadsheetId=self.sheets.spreadsheet_id,
-                    range=f"{sheet_name}!A1",
-                    valueInputOption="RAW",
-                    body={"values": compacted}
+            # If clear succeeded but update fails, restore original data (best-effort)
+            try:
+                self.sheets._execute_with_backoff(
+                    self.sheets.sheets.spreadsheets().values().update(
+                        spreadsheetId=self.sheets.spreadsheet_id,
+                        range=f"{sheet_name}!A1",
+                        valueInputOption="RAW",
+                        body={"values": buffered_compacted}
+                    )
                 )
-            )
+            except Exception as update_exc:
+                _log.error(
+                    f"{sheet_name} Kompaktierung Update fehlgeschlagen — versuche Wiederherstellung",
+                    extra={"error": str(update_exc)}
+                )
+                try:
+                    self.sheets._execute_with_backoff(
+                        self.sheets.sheets.spreadsheets().values().update(
+                            spreadsheetId=self.sheets.spreadsheet_id,
+                            range=f"{sheet_name}!A1",
+                            valueInputOption="RAW",
+                            body={"values": original_rows}
+                        )
+                    )
+                    _log.info(f"{sheet_name} Wiederherstellung nach fehlgeschlagenem Update erfolgreich")
+                except Exception as restore_exc:
+                    _log.error(
+                        f"{sheet_name} Wiederherstellung fehlgeschlagen — Sheet möglicherweise leer!",
+                        extra={"restore_error": str(restore_exc)}
+                    )
+                raise update_exc
             _log.info(f"{sheet_name} kompaktiert", extra={"kept": len(keep)})
 
     def load_known_hashes(self) -> Dict[str, dict]:
@@ -216,7 +242,7 @@ class StateTracker:
             # 2. Build index of existing shas to row_index (1-based)
             existing_index: dict[str, dict[str, Any]] = {}
             for i, row in enumerate(rows):
-                if len(row) >= 3:
+                if len(row) >= 3 and row[0] != "sha256":  # M-2 fix: skip header row
                     existing_index[row[0]] = {
                         "row_idx": i + 1,
                         "original": row[1],

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_drive_helpers.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_drive_helpers.py
@@ -150,3 +150,40 @@ class TestFetchDeltaChunk:
         assert next_token == "nxt"
         assert new_start == "new"
         assert mgr.execute_with_backoff.call_count == 1
+
+    def test_file_moved_outside_target_produces_scope_exit_event(self):
+        """T-4: BUG-3 fix — a file that moves out of the target folder tree must produce
+        a synthetic removed+scope_exit event instead of being silently dropped."""
+        from unittest.mock import patch as _patch
+        from shared.change_type_logic import determine_change_type
+
+        mgr = _make_manager(target_folder_id="TARGET")
+        # File has parents only outside the target tree
+        change_event = {
+            "fileId": "file_moved_out",
+            "removed": False,
+            "file": {
+                "id": "file_moved_out",
+                "name": "moved.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["outside_folder"],
+                "trashed": False,
+            },
+        }
+        api_response = {
+            "changes": [change_event],
+            "newStartPageToken": "tok_new",
+        }
+
+        with _patch.object(mgr, "is_in_target_folder", return_value=False), \
+             _patch.object(mgr, "execute_with_backoff", return_value=api_response):
+            changes, _next, _new_start = mgr.fetch_delta_chunk("tok_old")
+
+        assert len(changes) == 1, "moved-out-of-scope file must appear as a change event"
+        c = changes[0]
+        assert c.get("removed") is True, "scope-exit event must have removed=True"
+        assert c.get("scope_exit") is True, "scope-exit event must have scope_exit=True"
+
+        # change_type_logic must classify it as MOVED_OUT_OF_SCOPE, not REMOVED_OR_NO_ACCESS
+        ct = determine_change_type(c, known_file_details={}, is_initial=False)
+        assert ct == "MOVED_OUT_OF_SCOPE", f"expected MOVED_OUT_OF_SCOPE, got {ct}"

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_parallel_run_guard.py
@@ -48,6 +48,16 @@ class DummyStateTracker:
     def log_error(self, *args, **kwargs):
         pass
 
+    # T-1 fix: stubs needed for a full success-path run_pass1() invocation
+    def append_new_hashes(self, records):
+        pass
+
+    def append_dedupe_reports(self, records):
+        pass
+
+    def flush_duplicate_groups(self, groups):
+        pass
+
 
 class TestParallelRunGuardHelpers(unittest.TestCase):
     def test_active_foreign_lease_blocks_even_when_phase_idle(self):
@@ -182,6 +192,105 @@ class TestParallelRunGuardIntegration(unittest.TestCase):
             main_pass1.SheetManager = old_sheet_mgr
             main_pass1.DriveManager = old_drive_mgr
             main_pass1.CONTROL_SHEET_ID = old_control_sheet
+
+
+def _patch_pass1(state, mocked_drive_mgr):
+    """Return a dict of {attr: old_val} for monkey-patching main_pass1 and a restore callable."""
+    saved = {
+        "get_user_credentials": main_pass1.get_user_credentials,
+        "build": main_pass1.build,
+        "StateTracker": main_pass1.StateTracker,
+        "SheetManager": main_pass1.SheetManager,
+        "DriveManager": main_pass1.DriveManager,
+        "CONTROL_SHEET_ID": main_pass1.CONTROL_SHEET_ID,
+    }
+    main_pass1.get_user_credentials = lambda: None
+    main_pass1.build = lambda *a, **kw: object()
+    def _make_sheet_mock(*a, **kw):
+        m = mock.Mock()
+        m.read_all_rows.return_value = []
+        return m
+    main_pass1.SheetManager = _make_sheet_mock
+    main_pass1.StateTracker = lambda *a, **kw: state
+    main_pass1.DriveManager = lambda *a, **kw: mocked_drive_mgr
+    main_pass1.CONTROL_SHEET_ID = "sheet_test"
+    return saved
+
+
+def _restore_pass1(saved):
+    for k, v in saved.items():
+        setattr(main_pass1, k, v)
+
+
+class TestPass1SuccessPath(unittest.TestCase):
+    """T-1: verify BUG-1+2 fix — state values survive _release_lease() after a successful run."""
+
+    def test_initial_scan_state_persisted_after_run(self):
+        shared = SharedStateStore({})
+        state = DummyStateTracker(shared, owner_id="owner_t1", run_id="run_t1")
+
+        mocked_drive_mgr = mock.Mock()
+        mocked_drive_mgr.get_initial_token.return_value = "token_initial_123"
+        mocked_drive_mgr.walk_recursive_chunked.return_value = 0
+
+        saved = _patch_pass1(state, mocked_drive_mgr)
+        try:
+            main_pass1.run_pass1()
+        finally:
+            _restore_pass1(saved)
+
+        self.assertEqual(shared.data.get("current_phase"), "PASS1_DONE",
+                         "current_phase must be PASS1_DONE in the sheet after a successful run")
+        self.assertEqual(shared.data.get("ready_for_pass2_run_id"), "run_t1",
+                         "ready_for_pass2_run_id must be persisted so Pass 2 can pick it up")
+        self.assertEqual(shared.data.get("last_successful_run_id"), "run_t1",
+                         "last_successful_run_id must be persisted")
+        self.assertFalse(shared.data.get("lease_owner_id"),
+                         "lease_owner_id must be cleared after release")
+
+    def test_failed_run_persists_failed_phase(self):
+        shared = SharedStateStore({})
+        state = DummyStateTracker(shared, owner_id="owner_t1f", run_id="run_t1f")
+
+        mocked_drive_mgr = mock.Mock()
+        mocked_drive_mgr.get_initial_token.return_value = "tok"
+        mocked_drive_mgr.walk_recursive_chunked.side_effect = RuntimeError("simulated failure")
+
+        saved = _patch_pass1(state, mocked_drive_mgr)
+        try:
+            with self.assertRaises(RuntimeError):
+                main_pass1.run_pass1()
+        finally:
+            _restore_pass1(saved)
+
+        self.assertEqual(shared.data.get("current_phase"), "PASS1_FAILED",
+                         "current_phase must be PASS1_FAILED in the sheet after a failed run")
+        self.assertFalse(shared.data.get("lease_owner_id"),
+                         "lease_owner_id must be cleared even on failure")
+
+
+class TestPass1DeltaTokenPersistence(unittest.TestCase):
+    """T-2: verify BUG-2 fix — drive_start_page_token is advanced after a delta run."""
+
+    def test_delta_run_advances_page_token(self):
+        shared = SharedStateStore({"drive_start_page_token": "old_token"})
+        state = DummyStateTracker(shared, owner_id="owner_t2", run_id="run_t2")
+
+        mocked_drive_mgr = mock.Mock()
+        # One delta chunk: no file changes, returns newStartPageToken="new_token"
+        mocked_drive_mgr.fetch_delta_chunk.return_value = ([], None, "new_token")
+
+        saved = _patch_pass1(state, mocked_drive_mgr)
+        try:
+            main_pass1.run_pass1()
+        finally:
+            _restore_pass1(saved)
+
+        self.assertEqual(shared.data.get("drive_start_page_token"), "new_token",
+                         "drive_start_page_token must be advanced to the new token")
+        self.assertEqual(shared.data.get("in_progress_page_token"), "",
+                         "in_progress_page_token must be cleared after a completed delta run")
+        self.assertEqual(shared.data.get("current_phase"), "PASS1_DONE")
 
 
 if __name__ == "__main__":

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py
@@ -576,5 +576,96 @@ class PersonalBrainSmokeTest(unittest.TestCase):
             )
 
 
+class TestPurgedSourceCascade(unittest.TestCase):
+    """T-3: BUG-4 fix — PURGED sources must be tombstone-deleted from the Brain index."""
+
+    def test_purged_file_id_removed_from_source_registry(self):
+        """Index a source, then PURGE it. The JSONL entry must vanish on the next run."""
+        with tempfile.TemporaryDirectory() as td:
+            runtime = PersonalBrainRuntime(project_id="test", out_root=Path(td))
+            source_path = Path(td) / "20_index" / "published" / "00_source_registry.jsonl"
+
+            # --- Run 1: index the file ---
+            item = {
+                "file_id": "purge_me_file_id",
+                "source_path": "/fake/invoice.pdf",
+                "source_path_rel": "invoice.pdf",
+                "original_filename": "invoice.pdf",
+                "mime": "application/pdf",
+                "ext": ".pdf",
+                "content": {"title": "invoice.pdf"},
+            }
+            runtime.process_sources([item])
+
+            # Confirm it was indexed
+            lines_after_index = [l for l in source_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+            file_ids_after_index = [json.loads(l).get("file_id") for l in lines_after_index]
+            self.assertIn("purge_me_file_id", file_ids_after_index,
+                          "source must appear in registry after initial indexing")
+
+            # --- Run 2: PURGE the source (pass empty sources list + PURGED exclusion) ---
+            runtime.process_sources([], exclusions={"purge_me_file_id": "PURGED"})
+
+            # The PURGED entry must no longer appear in the source registry
+            lines_after_purge = [l for l in source_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+            file_ids_after_purge = [json.loads(l).get("file_id") for l in lines_after_purge]
+            self.assertNotIn("purge_me_file_id", file_ids_after_purge,
+                             "PURGED source must be removed from 00_source_registry.jsonl")
+
+    def test_purged_file_id_removed_from_record_index(self):
+        """Index a source with records, then PURGE it. Records must also vanish."""
+        with tempfile.TemporaryDirectory() as td:
+            runtime = PersonalBrainRuntime(project_id="test", out_root=Path(td))
+            record_path = Path(td) / "20_index" / "published" / "01_record_index.jsonl"
+
+            item = {
+                "file_id": "purge_record_target",
+                "source_path": "/fake/notes.txt",
+                "source_path_rel": "notes.txt",
+                "original_filename": "notes.txt",
+                "mime": "text/plain",
+                "ext": ".txt",
+                "content": {"title": "notes.txt", "raw_text": "hello world"},
+            }
+            runtime.process_sources([item])
+
+            lines_before = [l for l in record_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+            file_ids_before = [json.loads(l).get("file_id") for l in lines_before]
+            self.assertIn("purge_record_target", file_ids_before,
+                          "record must appear in index after initial indexing")
+
+            runtime.process_sources([], exclusions={"purge_record_target": "PURGED"})
+
+            lines_after = [l for l in record_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+            file_ids_after = [json.loads(l).get("file_id") for l in lines_after]
+            self.assertNotIn("purge_record_target", file_ids_after,
+                             "PURGED source records must be removed from 01_record_index.jsonl")
+
+    def test_excluded_source_is_not_deleted(self):
+        """EXCLUDED sources must NOT be removed — only PURGED ones are tombstoned."""
+        with tempfile.TemporaryDirectory() as td:
+            runtime = PersonalBrainRuntime(project_id="test", out_root=Path(td))
+            source_path = Path(td) / "20_index" / "published" / "00_source_registry.jsonl"
+
+            item = {
+                "file_id": "excluded_file_id",
+                "source_path": "/fake/doc.pdf",
+                "source_path_rel": "doc.pdf",
+                "original_filename": "doc.pdf",
+                "mime": "application/pdf",
+                "ext": ".pdf",
+                "content": {"title": "doc.pdf"},
+            }
+            runtime.process_sources([item])
+
+            # EXCLUDED — should not be tombstoned (just not re-ingested)
+            runtime.process_sources([], exclusions={"excluded_file_id": "EXCLUDED"})
+
+            lines = [l for l in source_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+            file_ids = [json.loads(l).get("file_id") for l in lines]
+            self.assertIn("excluded_file_id", file_ids,
+                          "EXCLUDED source must remain in the registry (only PURGED is tombstoned)")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_personal_brain_smoke.py
@@ -598,8 +598,8 @@ class TestPurgedSourceCascade(unittest.TestCase):
             runtime.process_sources([item])
 
             # Confirm it was indexed
-            lines_after_index = [l for l in source_path.read_text(encoding="utf-8").splitlines() if l.strip()]
-            file_ids_after_index = [json.loads(l).get("file_id") for l in lines_after_index]
+            lines_after_index = [ln for ln in source_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            file_ids_after_index = [json.loads(ln).get("file_id") for ln in lines_after_index]
             self.assertIn("purge_me_file_id", file_ids_after_index,
                           "source must appear in registry after initial indexing")
 
@@ -607,8 +607,8 @@ class TestPurgedSourceCascade(unittest.TestCase):
             runtime.process_sources([], exclusions={"purge_me_file_id": "PURGED"})
 
             # The PURGED entry must no longer appear in the source registry
-            lines_after_purge = [l for l in source_path.read_text(encoding="utf-8").splitlines() if l.strip()]
-            file_ids_after_purge = [json.loads(l).get("file_id") for l in lines_after_purge]
+            lines_after_purge = [ln for ln in source_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            file_ids_after_purge = [json.loads(ln).get("file_id") for ln in lines_after_purge]
             self.assertNotIn("purge_me_file_id", file_ids_after_purge,
                              "PURGED source must be removed from 00_source_registry.jsonl")
 
@@ -629,15 +629,15 @@ class TestPurgedSourceCascade(unittest.TestCase):
             }
             runtime.process_sources([item])
 
-            lines_before = [l for l in record_path.read_text(encoding="utf-8").splitlines() if l.strip()]
-            file_ids_before = [json.loads(l).get("file_id") for l in lines_before]
+            lines_before = [ln for ln in record_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            file_ids_before = [json.loads(ln).get("file_id") for ln in lines_before]
             self.assertIn("purge_record_target", file_ids_before,
                           "record must appear in index after initial indexing")
 
             runtime.process_sources([], exclusions={"purge_record_target": "PURGED"})
 
-            lines_after = [l for l in record_path.read_text(encoding="utf-8").splitlines() if l.strip()]
-            file_ids_after = [json.loads(l).get("file_id") for l in lines_after]
+            lines_after = [ln for ln in record_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            file_ids_after = [json.loads(ln).get("file_id") for ln in lines_after]
             self.assertNotIn("purge_record_target", file_ids_after,
                              "PURGED source records must be removed from 01_record_index.jsonl")
 
@@ -661,8 +661,8 @@ class TestPurgedSourceCascade(unittest.TestCase):
             # EXCLUDED — should not be tombstoned (just not re-ingested)
             runtime.process_sources([], exclusions={"excluded_file_id": "EXCLUDED"})
 
-            lines = [l for l in source_path.read_text(encoding="utf-8").splitlines() if l.strip()]
-            file_ids = [json.loads(l).get("file_id") for l in lines]
+            lines = [ln for ln in source_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            file_ids = [json.loads(ln).get("file_id") for ln in lines]
             self.assertIn("excluded_file_id", file_ids,
                           "EXCLUDED source must remain in the registry (only PURGED is tombstoned)")
 


### PR DESCRIPTION
## Summary
This PR addresses multiple critical bugs affecting state persistence, race conditions, and data integrity across the Pass1 scan phase, Brain indexing, and file management operations. The fixes ensure that state changes survive lease releases, prevent duplicate work on restarts, handle moved files correctly, and safely manage purged sources.

## Key Changes

### State Persistence & Lease Management (BUG-1, BUG-2)
- **main_pass1.py**: Add explicit `state.flush_state()` calls before `_release_lease()` to ensure state changes (phase, run_id, page tokens) persist to the sheet before the lease is released. This prevents state loss when the process crashes between state updates and lease release.
- **main_pass1.py**: Add 500ms sleep fence after `_claim_lease()` to reduce TOCTOU window before verification read (RISK-1 fix).
- **main_pass1.py**: Fix `_is_lease_stale()` to handle `TypeError` in addition to `ValueError` when parsing heartbeat timestamp (M-1 fix).

### Idempotency & Crash Recovery
- **main_apply_renames.py**: Track rename results in the Dedupe_Report sheet and skip rows already marked "SUCCESS" to prevent duplicate rename attempts on restart (RISK-3 fix). Batch update results periodically to bound memory usage.
- **main_safe_sort.py**: Load existing suggestions before processing to prevent duplicate suggestions when safe_sort is restarted mid-run (DM-2 fix).
- **shared/state_helpers.py**: Add buffering and recovery logic to `compact_reports()` — if the update fails after clearing, attempt to restore original data (RISK-4 fix).

### File Movement & Scope Tracking (BUG-3)
- **shared/drive_helpers.py**: Detect files that have moved outside the target folder tree and emit synthetic `removed=True, scope_exit=True` events instead of silently dropping them.
- **shared/change_type_logic.py**: Add `MOVED_OUT_OF_SCOPE` change type to properly classify files that exist in Drive but are no longer in the target folder.
- **tests/smoke/test_drive_helpers.py**: Add test verifying scope-exit event generation for moved files.

### Purged Source Handling (BUG-4)
- **personal_brain/runtime.py**: Collect file_ids marked as "PURGED" in exclusions and pass them to the writer for tombstone deletion.
- **personal_brain/writers.py**: Extend `_write_jsonl()` to accept `purged_file_ids` set and skip (delete) existing JSONL entries for purged sources during the merge-write operation.
- **tests/smoke/test_personal_brain_smoke.py**: Add comprehensive tests for purged source cascade (removal from both source registry and record index) and verify EXCLUDED sources are not deleted.

### Data Integrity Fixes
- **shared/state_helpers.py**: Fix `flush_duplicate_groups()` to skip header row when building the existing SHA index (M-2 fix).
- **main_apply_sort.py**: Move parent-fetch inside the retry closure so each retry uses fresh parent data rather than stale captured values (M-3 fix).

### Test Coverage
- **tests/smoke/test_parallel_run_guard.py**: Add stub methods to `DummyStateTracker` and new test classes `TestPass1SuccessPath` and `TestPass1DeltaTokenPersistence` to verify state persistence across successful and failed runs, and page token advancement in delta mode.

## Notable Implementation Details
- State flush operations are strategically placed before operations that could lose state (lease release, compaction).
- Rename and suggestion tracking uses sheet columns to maintain idempotency across restarts.
- Purged source deletion uses streaming merge-write to avoid loading entire indices into memory.
- Scope-exit detection leverages existing `is_in_target_folder()` checks to identify moved files without additional API calls.

https://claude.ai/code/session_017CKAtbXgPc9jmyYCo4oJ7P