### PR TITLE
harden: close gaps A-G — lifecycle purge, scope exit, job locks, stale memory cleanup

### DIFF
--- a/bummdidumm_os_v5_final_release/README.md
+++ b/bummdidumm_os_v5_final_release/README.md
@@ -150,5 +150,82 @@ Pass 2 erweitert den klassischen Delta-Export um export-aware Parsing nach `20_i
 Einstiegspunkt: `personal_brain/runtime.py`, aufgerufen aus `main_pass2.py`.
 
 ### Knowledge Lifecycle / Exclusions
-- Tab `Knowledge_Exclusions` steuert `ACTIVE`, `EXCLUDED`, `PURGED` pro `file_id`.
-- Exclusions gelten auch für abgeleitete Archive-Subeinträge (ZIP-Inhalte via `bundle_id`).
+
+Tab `Knowledge_Exclusions` steuert `ACTIVE`, `EXCLUDED`, `PURGED` pro `file_id`.
+Exclusions gelten auch für abgeleitete Archive-Subeinträge (ZIP-Inhalte via `bundle_id`).
+
+#### Finale Lifecycle-Semantik (bindend)
+
+| Status | Bedeutung | Brain-Records | Re-Ingest |
+|--------|-----------|---------------|-----------|
+| `ACTIVE` | Quelle ist aktiv im Scope und wird indiziert | Indiziert + aktualisiert | Ja |
+| `EXCLUDED` | Quelle wird übersprungen (manuell oder auto bei gelöschten/scope-exited) | **Erhalten** | Nein |
+| `PURGED` | Quelle vollständig aus publizierten Indizes entfernt | **Tombstoned** | Nein |
+
+**Auto-Exclusion-Regel:** Quellen mit `change_type` in `{DELETED, TRASHED, REMOVED_OR_NO_ACCESS, MOVED_OUT_OF_SCOPE}` werden im Brain-Runtime automatisch als `EXCLUDED` behandelt — bestehende Brain-Records bleiben erhalten, neuer Ingest wird gestoppt. Explizite `Knowledge_Exclusions`-Einträge haben immer Vorrang.
+
+#### PURGED — was konkret passiert
+
+Wenn eine Datei auf `PURGED` gesetzt ist (oder `EXCLUDED` + manuell auf PURGED hochgestuft), entfernt der nächste Pass-2-Lauf folgendes aus den publizierten Artefakten:
+
+| Artefakt | Entfernungslogik |
+|----------|-----------------|
+| `00_source_registry.jsonl` | Einträge mit `file_id` in purged_file_ids → gelöscht |
+| `01_record_index.jsonl` | Einträge mit `file_id` in purged_file_ids → gelöscht |
+| `02_entity_index.jsonl` | Entitäten, deren **alle** `source_ids` zu purged file_ids gehören → gelöscht |
+| `03_relation_index.jsonl` | Relationen, deren **alle** `source_ids` zu purged file_ids gehören → gelöscht |
+| `04_daily_memory/*.json` | Tagesdateien ohne verbleibende Records → automatisch gelöscht |
+| `04_weekly_memory/*.json` | Wochendateien ohne verbleibende Tage → automatisch gelöscht |
+| `file_topics.json` | Einträge für purged `file_id`s → entfernt |
+
+**Partieller Purge:** Entities/Relations, die auch auf nicht-gepurgten Quellen basieren, werden NICHT tombstoned — sie konvergieren beim nächsten Re-Index der überlebenden Quellen.
+
+#### Scope Exit — was passiert wenn eine Datei den Scope verlässt
+
+1. **Pass 1 / Drive-Level:** `drive_helpers.py` erkennt Dateien außerhalb des `TARGET_FOLDER_ID`-Baums und setzt synthetisch `scope_exit=True` → `change_type = MOVED_OUT_OF_SCOPE` in Dedupe_Report.
+2. **Pass 2 / JSONL-Delta:** `MOVED_OUT_OF_SCOPE` wird in die `valid_statuses` aufgenommen und als `event_only_no_content_processing` weitergeleitet.
+3. **Brain-Runtime:** Auto-EXCLUDED → Parser wird nicht aufgerufen, bestehende Records bleiben erhalten.
+4. **Vollständige Entfernung:** Nur durch manuelles Setzen von `PURGED` in `Knowledge_Exclusions`.
+
+### Parallelität / Job Locks
+
+**Pass 1** schützt sich über ein vollständiges Lease-System mit Heartbeat
+(`lease_owner_id`, `lease_heartbeat_at`, `lease_acquired_at`) inkl. TOCTOU-Fence (500ms).
+
+**Downstream Jobs** (Safe Sort, Apply Sort, Apply Renames) nutzen einfache Job-Level Locks
+ohne Heartbeat (kürzere Laufzeit). Implementiert via `StateTracker.acquire_job_lock()` /
+`release_job_lock()` in `shared/state_helpers.py`.
+
+| State-Key | Bedeutung |
+|-----------|-----------|
+| `{job_name}_lock_owner` | `owner_id` des Lock-Inhabers |
+| `{job_name}_lock_at` | ISO-UTC Zeitstempel der Übernahme |
+
+Stale Locks (älter als Timeout, Default: 600s) werden automatisch übernommen.
+
+**Konfiguration via Env-Variablen:**
+
+| Variable | Default | Gilt für |
+|----------|---------|----------|
+| `SAFE_SORT_LOCK_TIMEOUT_SEC` | 600 | Safe Sort |
+| `APPLY_SORT_LOCK_TIMEOUT_SEC` | 600 | Apply Sort |
+| `APPLY_RENAMES_LOCK_TIMEOUT_SEC` | 600 | Apply Renames |
+
+Wenn ein Job geblockt wird, loggt er eine Warning und beendet sich ohne Fehler. Ein nachfolgender Cron-Lauf kann ihn erneut starten.
+
+**Bekannte Restgrenzen:** Die Sheets-API ist eventual-consistent. Concurrent Sheets-API-Calls mit <500ms Abstand können nicht vollständig verhindert werden. Der Job-Lock bietet Schutz im Sekunden-Bereich, nicht im Millisekunden-Bereich.
+
+### Operatives Runbook
+
+**Datei manuell purgen:**
+1. `Knowledge_Exclusions` Tab öffnen
+2. `file_id` der Datei in Spalte A eintragen, Status `PURGED` in Spalte C setzen
+3. Nächsten Pass-2-Lauf abwarten → Artefakte werden bereinigt
+
+**Stale Lock manuell löschen:**
+Im State-Tab die Schlüssel `{job_name}_lock_owner` und `{job_name}_lock_at` auf leer setzen.
+Alternativ wartet das System nach `{JOB}_LOCK_TIMEOUT_SEC` Sekunden automatisch auf Takeover.
+
+**Tages-Memory-Datei neu bauen:**
+Pass 2 erneut ausführen. `write_daily_memory()` rebuildet immer aus dem aktuellen
+`01_record_index.jsonl` und löscht dabei Tagesdateien ohne verbleibende Records.

--- a/bummdidumm_os_v5_final_release/main_apply_renames.py
+++ b/bummdidumm_os_v5_final_release/main_apply_renames.py
@@ -23,94 +23,101 @@ def run_apply_renames():
     state = StateTracker(sheet_mgr)
     from shared.log import get_logger
     log = get_logger("apply_renames", phase="APPLY_RENAMES")
-    log.info("Rename Job gestartet")
 
-    state.set_val("current_phase", "APPLY_RENAMES")
-    state.flush_state()
-
-    current_run_id = state.get_val("last_successful_run_id")
-
-    if not current_run_id:
-        state.log_error("RENAME", "SYSTEM", "", "NoRunID", "Kein aktueller Run_ID gefunden.")
-        state.set_val("current_phase", "IDLE")
-        state.flush_state()
+    _lock_timeout = int(os.environ.get("APPLY_RENAMES_LOCK_TIMEOUT_SEC", "600"))
+    if not state.acquire_job_lock("apply_renames", timeout_sec=_lock_timeout):
+        log.warning("Apply Renames abgebrochen: anderer Prozess hält den Lock")
         return
 
-    processed = 0
-    errors = 0
-    update_requests = []
+    try:
+        log.info("Rename Job gestartet")
+        state.set_val("current_phase", "APPLY_RENAMES")
+        state.flush_state()
 
-    rename_result_col = sheet_mgr.DEDUPE_COL.get("rename_result", 17)
+        current_run_id = state.get_val("last_successful_run_id")
 
-    def _col_letter(n: int) -> str:
-        """Convert 0-based column index to Sheets A1 column letter (handles AA, AB, …)."""
-        res = ""
-        while n >= 0:
-            res = chr(ord("A") + (n % 26)) + res
-            n = (n // 26) - 1
-        return res
+        if not current_run_id:
+            state.log_error("RENAME", "SYSTEM", "", "NoRunID", "Kein aktueller Run_ID gefunden.")
+            return
 
-    col_letter = _col_letter(rename_result_col)
+        processed = 0
+        errors = 0
+        update_requests = []
 
-    for row_idx, row in sheet_mgr.read_rows_chunked_with_row_numbers("Dedupe_Report", chunk_size=1000):
-        if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) - 1 or row[0] == "run_utc":
-            continue
-        if row[sheet_mgr.DEDUPE_COL["run_id"]] != current_run_id:
-            continue
+        rename_result_col = sheet_mgr.DEDUPE_COL.get("rename_result", 17)
 
-        # RISK-3 fix: idempotency guard — skip rows already successfully renamed
-        existing_rename_result = row[rename_result_col] if len(row) > rename_result_col else ""
-        if existing_rename_result == "SUCCESS":
-            continue
+        def _col_letter(n: int) -> str:
+            """Convert 0-based column index to Sheets A1 column letter (handles AA, AB, …)."""
+            res = ""
+            while n >= 0:
+                res = chr(ord("A") + (n % 26)) + res
+                n = (n // 26) - 1
+            return res
 
-        file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
-        current_name = row[sheet_mgr.DEDUPE_COL["name"]]
-        suggested_name = row[sheet_mgr.DEDUPE_COL["suggested_name"]]
+        col_letter = _col_letter(rename_result_col)
 
-        if suggested_name and suggested_name != current_name:
-            result_val = None
-            try:
-                params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
-                def _update_name():
-                    return drive_service.files().update(
-                        fileId=file_id,
-                        body={"name": suggested_name},
-                        **params
-                    ).execute()
-                drive_mgr.execute_with_backoff(_update_name)
-                result_val = "SUCCESS"
-                processed += 1
-            except Exception as e:
-                errors += 1
-                result_val = f"FAILED: {str(e)[:80]}"
-                state.log_error("RENAME", file_id, current_name, "UpdateError", str(e))
+        for row_idx, row in sheet_mgr.read_rows_chunked_with_row_numbers("Dedupe_Report", chunk_size=1000):
+            if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) - 1 or row[0] == "run_utc":
+                continue
+            if row[sheet_mgr.DEDUPE_COL["run_id"]] != current_run_id:
+                continue
 
-            update_requests.append({
-                "range": f"Dedupe_Report!{col_letter}{row_idx}",
-                "values": [[result_val]]
-            })
+            # RISK-3 fix: idempotency guard — skip rows already successfully renamed
+            existing_rename_result = row[rename_result_col] if len(row) > rename_result_col else ""
+            if existing_rename_result == "SUCCESS":
+                continue
 
-            # Flush periodically to bound memory
-            if len(update_requests) >= 50:
-                def _batch():
-                    return sheets_service.spreadsheets().values().batchUpdate(
-                        spreadsheetId=CONTROL_SHEET_ID,
-                        body={"valueInputOption": "RAW", "data": update_requests}
-                    ).execute()
-                sheet_mgr._execute_with_backoff(_batch())
-                update_requests = []
+            file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
+            current_name = row[sheet_mgr.DEDUPE_COL["name"]]
+            suggested_name = row[sheet_mgr.DEDUPE_COL["suggested_name"]]
 
-    if update_requests:
-        def _batch_final():
-            return sheets_service.spreadsheets().values().batchUpdate(
-                spreadsheetId=CONTROL_SHEET_ID,
-                body={"valueInputOption": "RAW", "data": update_requests}
-            ).execute()
-        sheet_mgr._execute_with_backoff(_batch_final())
+            if suggested_name and suggested_name != current_name:
+                result_val = None
+                try:
+                    params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
+                    def _update_name():
+                        return drive_service.files().update(
+                            fileId=file_id,
+                            body={"name": suggested_name},
+                            **params
+                        ).execute()
+                    drive_mgr.execute_with_backoff(_update_name)
+                    result_val = "SUCCESS"
+                    processed += 1
+                except Exception as e:
+                    errors += 1
+                    result_val = f"FAILED: {str(e)[:80]}"
+                    state.log_error("RENAME", file_id, current_name, "UpdateError", str(e))
 
-    state.log_run("RENAME", "SUCCESS", processed, errors)
-    state.set_val("current_phase", "IDLE")
-    state.flush_state()
+                update_requests.append({
+                    "range": f"Dedupe_Report!{col_letter}{row_idx}",
+                    "values": [[result_val]]
+                })
+
+                # Flush periodically to bound memory
+                if len(update_requests) >= 50:
+                    def _batch():
+                        return sheets_service.spreadsheets().values().batchUpdate(
+                            spreadsheetId=CONTROL_SHEET_ID,
+                            body={"valueInputOption": "RAW", "data": update_requests}
+                        ).execute()
+                    sheet_mgr._execute_with_backoff(_batch())
+                    update_requests = []
+
+        if update_requests:
+            def _batch_final():
+                return sheets_service.spreadsheets().values().batchUpdate(
+                    spreadsheetId=CONTROL_SHEET_ID,
+                    body={"valueInputOption": "RAW", "data": update_requests}
+                ).execute()
+            sheet_mgr._execute_with_backoff(_batch_final())
+
+        state.log_run("RENAME", "SUCCESS", processed, errors)
+
+    finally:
+        state.set_val("current_phase", "IDLE")
+        state.flush_state()
+        state.release_job_lock("apply_renames")
 
 if __name__ == "__main__":
     run_apply_renames()

--- a/bummdidumm_os_v5_final_release/main_apply_sort.py
+++ b/bummdidumm_os_v5_final_release/main_apply_sort.py
@@ -24,97 +24,104 @@ def run_apply_sort():
     state = StateTracker(sheet_mgr)
     from shared.log import get_logger
     log = get_logger("apply_sort", phase="APPLY_SORT")
-    log.info("Apply Sort gestartet")
 
-    state.set_val("current_phase", "APPLY_SORT")
-    state.flush_state()
-    current_run_id = state.get_val("last_successful_run_id")
-    if not current_run_id:
-        state.log_error("APPLY_SORT", "SYSTEM", "", "NoRunID", "Kein aktueller Run_ID gefunden.")
-        state.set_val("current_phase", "IDLE")
-        state.flush_state()
+    _lock_timeout = int(os.environ.get("APPLY_SORT_LOCK_TIMEOUT_SEC", "600"))
+    if not state.acquire_job_lock("apply_sort", timeout_sec=_lock_timeout):
+        log.warning("Apply Sort abgebrochen: anderer Prozess hält den Lock")
         return
 
-    processed = 0
-    errors = 0
+    try:
+        log.info("Apply Sort gestartet")
+        state.set_val("current_phase", "APPLY_SORT")
+        state.flush_state()
+        current_run_id = state.get_val("last_successful_run_id")
+        if not current_run_id:
+            state.log_error("APPLY_SORT", "SYSTEM", "", "NoRunID", "Kein aktueller Run_ID gefunden.")
+            return
 
-    update_requests = []
+        processed = 0
+        errors = 0
 
-    for row_idx, row in sheet_mgr.read_rows_chunked_with_row_numbers("Sorting_Suggestions", chunk_size=1000):
-        if len(row) < len(sheet_mgr.headers["Sorting_Suggestions"]) or row[0] == "run_id" or row[0] != current_run_id:
-            continue
+        update_requests = []
 
-        file_id = row[sheet_mgr.SORT_COL["file_id"]]
-        current_name = row[sheet_mgr.SORT_COL["name"]]
-        target_folder_id = row[sheet_mgr.SORT_COL["suggested_target_folder_id"]]
-        action_mode = row[sheet_mgr.SORT_COL["action_mode"]]
-        move_result = row[sheet_mgr.SORT_COL["move_result"]]
+        for row_idx, row in sheet_mgr.read_rows_chunked_with_row_numbers("Sorting_Suggestions", chunk_size=1000):
+            if len(row) < len(sheet_mgr.headers["Sorting_Suggestions"]) or row[0] == "run_id" or row[0] != current_run_id:
+                continue
 
-        if action_mode in ["SAFE", "SWEEP_TRASH"] and (target_folder_id or action_mode == "SWEEP_TRASH") and move_result == "PENDING":
-            try:
-                params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
+            file_id = row[sheet_mgr.SORT_COL["file_id"]]
+            current_name = row[sheet_mgr.SORT_COL["name"]]
+            target_folder_id = row[sheet_mgr.SORT_COL["suggested_target_folder_id"]]
+            action_mode = row[sheet_mgr.SORT_COL["action_mode"]]
+            move_result = row[sheet_mgr.SORT_COL["move_result"]]
 
-                if action_mode == "SWEEP_TRASH":
-                    # Mark explicitly as trashed
-                    def _trash():
-                        return drive_service.files().update(
-                            fileId=file_id,
-                            body={"trashed": True},
-                            **params
+            if action_mode in ["SAFE", "SWEEP_TRASH"] and (target_folder_id or action_mode == "SWEEP_TRASH") and move_result == "PENDING":
+                try:
+                    params = {"supportsAllDrives": True} if ENABLE_SHARED_DRIVES else {}
+
+                    if action_mode == "SWEEP_TRASH":
+                        # Mark explicitly as trashed
+                        def _trash():
+                            return drive_service.files().update(
+                                fileId=file_id,
+                                body={"trashed": True},
+                                **params
+                            ).execute()
+                        drive_mgr.execute_with_backoff(_trash)
+                        result_val = "SUCCESS_TRASHED"
+                    else:
+                        # M-3 fix: fetch parents inside the retry closure so each retry uses
+                        # fresh parent data rather than a value captured before the first attempt.
+                        def _move_file():
+                            meta = drive_service.files().get(
+                                fileId=file_id, fields="parents", **params
+                            ).execute()
+                            prev = ",".join(meta.get("parents", []))
+                            return drive_service.files().update(
+                                fileId=file_id,
+                                addParents=target_folder_id,
+                                removeParents=prev,
+                                **params
+                            ).execute()
+                        drive_mgr.execute_with_backoff(_move_file)
+                        result_val = "SUCCESS"
+
+                    processed += 1
+                except Exception as e:
+                    errors += 1
+                    state.log_error("APPLY_SORT", file_id, current_name, "MoveError", str(e))
+                    result_val = f"FAILED: {str(e)[:80]}"
+
+                update_requests.append({
+                    "range": f"Sorting_Suggestions!M{row_idx}",
+                    "values": [[result_val]]
+                })
+
+                # Flush periodically to not build up a massive array in memory,
+                # but still benefit from batched update performance.
+                if len(update_requests) >= 50:
+                    def _batch_update_1():
+                        return sheets_service.spreadsheets().values().batchUpdate(
+                            spreadsheetId=CONTROL_SHEET_ID,
+                            body={"valueInputOption": "RAW", "data": update_requests}
                         ).execute()
-                    drive_mgr.execute_with_backoff(_trash)
-                    result_val = "SUCCESS_TRASHED"
-                else:
-                    # M-3 fix: fetch parents inside the retry closure so each retry uses
-                    # fresh parent data rather than a value captured before the first attempt.
-                    def _move_file():
-                        meta = drive_service.files().get(
-                            fileId=file_id, fields="parents", **params
-                        ).execute()
-                        prev = ",".join(meta.get("parents", []))
-                        return drive_service.files().update(
-                            fileId=file_id,
-                            addParents=target_folder_id,
-                            removeParents=prev,
-                            **params
-                        ).execute()
-                    drive_mgr.execute_with_backoff(_move_file)
-                    result_val = "SUCCESS"
+                    sheet_mgr._execute_with_backoff(_batch_update_1)
+                    update_requests = []
 
-                processed += 1
-            except Exception as e:
-                errors += 1
-                state.log_error("APPLY_SORT", file_id, current_name, "MoveError", str(e))
-                result_val = f"FAILED: {str(e)[:80]}"
+        if update_requests:
+            def _batch_update_2():
+                return sheets_service.spreadsheets().values().batchUpdate(
+                    spreadsheetId=CONTROL_SHEET_ID,
+                    body={"valueInputOption": "RAW", "data": update_requests}
+                ).execute()
+            sheet_mgr._execute_with_backoff(_batch_update_2)
 
-            update_requests.append({
-                "range": f"Sorting_Suggestions!M{row_idx}",
-                "values": [[result_val]]
-            })
+        state.log_run("APPLY_SORT", "SUCCESS", processed, errors)
+        log.info("Apply Sort beendet", extra={"processed": processed, "errors": errors})
 
-            # Flush periodically to not build up a massive array in memory,
-            # but still benefit from batched update performance.
-            if len(update_requests) >= 50:
-                def _batch_update_1():
-                    return sheets_service.spreadsheets().values().batchUpdate(
-                        spreadsheetId=CONTROL_SHEET_ID,
-                        body={"valueInputOption": "RAW", "data": update_requests}
-                    ).execute()
-                sheet_mgr._execute_with_backoff(_batch_update_1)
-                update_requests = []
-
-    if update_requests:
-        def _batch_update_2():
-            return sheets_service.spreadsheets().values().batchUpdate(
-                spreadsheetId=CONTROL_SHEET_ID,
-                body={"valueInputOption": "RAW", "data": update_requests}
-            ).execute()
-        sheet_mgr._execute_with_backoff(_batch_update_2)
-
-    state.log_run("APPLY_SORT", "SUCCESS", processed, errors)
-    state.set_val("current_phase", "IDLE")
-    state.flush_state()
-    log.info("Apply Sort beendet", extra={"processed": processed, "errors": errors})
+    finally:
+        state.set_val("current_phase", "IDLE")
+        state.flush_state()
+        state.release_job_lock("apply_sort")
 
 
 if __name__ == "__main__":

--- a/bummdidumm_os_v5_final_release/main_pass2.py
+++ b/bummdidumm_os_v5_final_release/main_pass2.py
@@ -356,7 +356,9 @@ def run_pass2():
 
             # Validiere, welche Records wir überhaupt an das AI-OS im JSONL weiterleiten.
             # Wir lassen "DUPLICATE" und "SKIPPED_SIZE" weg.
-            valid_statuses = ("ORIGINAL", "ORIGINAL_RESUMED", "UNCHANGED_CONTENT", "DELETED", "TRASHED", "REMOVED_OR_NO_ACCESS")
+            # MOVED_OUT_OF_SCOPE wird eingeschlossen, damit der Brain-Index scope-exits
+            # als event_only empfängt und abgeleitete Einträge bereinigen kann.
+            valid_statuses = ("ORIGINAL", "ORIGINAL_RESUMED", "UNCHANGED_CONTENT", "DELETED", "TRASHED", "REMOVED_OR_NO_ACCESS", "MOVED_OUT_OF_SCOPE")
             if not status.startswith(valid_statuses):
                 continue
 
@@ -422,7 +424,9 @@ def run_pass2():
                     state.log_error("PASS_2", file_id, rec.name, "OCRError", f"Fehler bei der OCR-Extraktion: {str(e)}")
 
             # Pfad B: Statusereignisse ohne OCR
-            elif change_type in ["DELETED", "TRASHED", "REMOVED_OR_NO_ACCESS", "MOVED", "RENAMED", "UNCHANGED_CONTENT_METADATA_ONLY"] or status == "UNCHANGED_CONTENT":
+            elif change_type in ["DELETED", "TRASHED", "REMOVED_OR_NO_ACCESS", "MOVED_OUT_OF_SCOPE",
+                                  "MOVED", "RENAMED", "UNCHANGED_CONTENT_METADATA_ONLY"] \
+                    or status in ("UNCHANGED_CONTENT", "MOVED_OUT_OF_SCOPE"):
                 # Kein OCR, wir signalisieren dem nachgelagerten System nur die Bestandsänderung
                 rec.notes = "event_only_no_content_processing"
 

--- a/bummdidumm_os_v5_final_release/main_safe_sort.py
+++ b/bummdidumm_os_v5_final_release/main_safe_sort.py
@@ -21,143 +21,153 @@ def run_safe_sort():
     state = StateTracker(sheet_mgr)
     from shared.log import get_logger
     log = get_logger("safe_sort", phase="SAFE_SORT")
-    log.info("Safe Sort gestartet")
 
-    folder_registry_rows = sheet_mgr.read_all_rows("Folder_Registry", "A:E")
-    folder_registry = {}
-    for row in folder_registry_rows:
-        if len(row) >= 5 and row[0] != "folder_key":
-            folder_registry[row[0]] = {
-                "folder_name": row[1],
-                "folder_id": row[2],
-                "parent_folder_id": row[3],
-                "full_path": row[4],
-            }
-
-    if not folder_registry:
-        state.log_error("SAFE_SORT", "SYSTEM", "", "NoRegistry", "Folder_Registry ist leer. Bitte zuerst 'Ordnerstruktur initialisieren' ausführen.")
+    _lock_timeout = int(os.environ.get("SAFE_SORT_LOCK_TIMEOUT_SEC", "600"))
+    if not state.acquire_job_lock("safe_sort", timeout_sec=_lock_timeout):
+        log.warning("Safe Sort abgebrochen: anderer Prozess hält den Lock")
         return
 
-    sorter = SortingRules(folder_registry)
-    current_run_id = state.get_val("last_successful_run_id")
-    if not current_run_id:
-        state.log_error("SAFE_SORT", "SYSTEM", "", "NoRunID", "Kein erfolgreicher Pass 1 gefunden.")
-        return
+    try:
+        log.info("Safe Sort gestartet")
 
-    known = state.load_known_hashes()
-    known_file_ids = set(known.keys())
+        folder_registry_rows = sheet_mgr.read_all_rows("Folder_Registry", "A:E")
+        folder_registry = {}
+        for row in folder_registry_rows:
+            if len(row) >= 5 and row[0] != "folder_key":
+                folder_registry[row[0]] = {
+                    "folder_name": row[1],
+                    "folder_id": row[2],
+                    "parent_folder_id": row[3],
+                    "full_path": row[4],
+                }
 
-    # Load semantic hints (file_id → primary topic) for sorting decisions.
-    # Prefer the compact file_topics.json written by Pass 2 writers; fall back to
-    # streaming the full record index for installations that predate this file.
-    from pathlib import Path
-    import json
-    import logging
-    semantic_hints: dict[str, str] = {}
-    brain_index_root = Path(os.environ.get("BRAIN_INDEX_ROOT", str(Path(__file__).parent / "brain_index")))
-    if "K_SERVICE" in os.environ and not os.environ.get("BRAIN_INDEX_ROOT"):
-        log.warning("BRAIN_INDEX_ROOT is not set in Cloud Run. Semantic hints will not be available.")
+        if not folder_registry:
+            state.log_error("SAFE_SORT", "SYSTEM", "", "NoRegistry", "Folder_Registry ist leer. Bitte zuerst 'Ordnerstruktur initialisieren' ausführen.")
+            return
 
-    hint_path = brain_index_root / "20_index" / "published" / "file_topics.json"
-    if hint_path.exists():
-        try:
-            loaded = json.loads(hint_path.read_text(encoding="utf-8"))
-            # Filter to known file_ids to keep the dict bounded.
-            semantic_hints = {k: v for k, v in loaded.items() if not known_file_ids or k in known_file_ids}
-        except Exception as e:
-            logging.debug(f"Failed to load topic hints file: {e}")
-    else:
-        # Fallback: stream record index (legacy path, before hints file was generated).
-        registry_path = brain_index_root / "20_index" / "published" / "01_record_index.jsonl"
-        if registry_path.exists():
+        sorter = SortingRules(folder_registry)
+        current_run_id = state.get_val("last_successful_run_id")
+        if not current_run_id:
+            state.log_error("SAFE_SORT", "SYSTEM", "", "NoRunID", "Kein erfolgreicher Pass 1 gefunden.")
+            return
+
+        known = state.load_known_hashes()
+        known_file_ids = set(known.keys())
+
+        # Load semantic hints (file_id → primary topic) for sorting decisions.
+        # Prefer the compact file_topics.json written by Pass 2 writers; fall back to
+        # streaming the full record index for installations that predate this file.
+        from pathlib import Path
+        import json
+        import logging
+        semantic_hints: dict[str, str] = {}
+        brain_index_root = Path(os.environ.get("BRAIN_INDEX_ROOT", str(Path(__file__).parent / "brain_index")))
+        if "K_SERVICE" in os.environ and not os.environ.get("BRAIN_INDEX_ROOT"):
+            log.warning("BRAIN_INDEX_ROOT is not set in Cloud Run. Semantic hints will not be available.")
+
+        hint_path = brain_index_root / "20_index" / "published" / "file_topics.json"
+        if hint_path.exists():
             try:
-                with registry_path.open(encoding="utf-8") as rh:
-                    for line in rh:
-                        if not line.strip():
-                            continue
-                        try:
-                            s_data = json.loads(line)
-                            f_id = s_data.get("file_id")
-                            if f_id and (not known_file_ids or f_id in known_file_ids):
-                                topics = s_data.get("topics", [])
-                                if topics:
-                                    semantic_hints[f_id] = topics[0]
-                        except Exception as e:
-                            logging.debug(f"Failed to parse line in record index: {e}")
+                loaded = json.loads(hint_path.read_text(encoding="utf-8"))
+                # Filter to known file_ids to keep the dict bounded.
+                semantic_hints = {k: v for k, v in loaded.items() if not known_file_ids or k in known_file_ids}
             except Exception as e:
-                logging.debug(f"Failed to read record index for semantic hints: {e}")
+                logging.debug(f"Failed to load topic hints file: {e}")
+        else:
+            # Fallback: stream record index (legacy path, before hints file was generated).
+            registry_path = brain_index_root / "20_index" / "published" / "01_record_index.jsonl"
+            if registry_path.exists():
+                try:
+                    with registry_path.open(encoding="utf-8") as rh:
+                        for line in rh:
+                            if not line.strip():
+                                continue
+                            try:
+                                s_data = json.loads(line)
+                                f_id = s_data.get("file_id")
+                                if f_id and (not known_file_ids or f_id in known_file_ids):
+                                    topics = s_data.get("topics", [])
+                                    if topics:
+                                        semantic_hints[f_id] = topics[0]
+                            except Exception as e:
+                                logging.debug(f"Failed to parse line in record index: {e}")
+                except Exception as e:
+                    logging.debug(f"Failed to read record index for semantic hints: {e}")
 
-    suggestions = []
-    processed = 0
-    errors = 0
+        suggestions = []
+        processed = 0
+        errors = 0
 
-    # DM-2 fix: load already-written suggestions for this run to prevent duplicates
-    # when safe_sort is restarted mid-run (crash recovery).
-    existing_suggestion_file_ids: set = set()
-    for ex_row in sheet_mgr.read_all_rows("Sorting_Suggestions", "A:B"):
-        if len(ex_row) >= 2 and ex_row[0] == current_run_id:
-            existing_suggestion_file_ids.add(ex_row[1])
+        # DM-2 fix: load already-written suggestions for this run to prevent duplicates
+        # when safe_sort is restarted mid-run (crash recovery).
+        existing_suggestion_file_ids: set = set()
+        for ex_row in sheet_mgr.read_all_rows("Sorting_Suggestions", "A:B"):
+            if len(ex_row) >= 2 and ex_row[0] == current_run_id:
+                existing_suggestion_file_ids.add(ex_row[1])
 
-    for chunk_rows in sheet_mgr.read_rows_chunked("Dedupe_Report", chunk_size=1000):
-        for row in chunk_rows:
-            if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) or row[0] == "run_utc" or row[1] != current_run_id:
-                continue
+        for chunk_rows in sheet_mgr.read_rows_chunked("Dedupe_Report", chunk_size=1000):
+            for row in chunk_rows:
+                if len(row) < len(sheet_mgr.headers["Dedupe_Report"]) or row[0] == "run_utc" or row[1] != current_run_id:
+                    continue
 
-            file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
-            if file_id in existing_suggestion_file_ids:
-                continue  # DM-2 fix: already suggested for this run
-            name = row[sheet_mgr.DEDUPE_COL["name"]]
-            mime_type = row[sheet_mgr.DEDUPE_COL["mime_type"]]
-            status = row[sheet_mgr.DEDUPE_COL["status"]]
-            current_path = row[sheet_mgr.DEDUPE_COL["path"]]
+                file_id = row[sheet_mgr.DEDUPE_COL["file_id"]]
+                if file_id in existing_suggestion_file_ids:
+                    continue  # DM-2 fix: already suggested for this run
+                name = row[sheet_mgr.DEDUPE_COL["name"]]
+                mime_type = row[sheet_mgr.DEDUPE_COL["mime_type"]]
+                status = row[sheet_mgr.DEDUPE_COL["status"]]
+                current_path = row[sheet_mgr.DEDUPE_COL["path"]]
 
-            current_parent_id = ""
-            meta = known.get(file_id, {})
-            if meta.get("parent_ids_sorted"):
-                current_parent_id = meta["parent_ids_sorted"].split(",")[0]
+                current_parent_id = ""
+                meta = known.get(file_id, {})
+                if meta.get("parent_ids_sorted"):
+                    current_parent_id = meta["parent_ids_sorted"].split(",")[0]
 
-            if not current_parent_id:
-                current_parent_id = "N/A"
+                if not current_parent_id:
+                    current_parent_id = "N/A"
 
-            notes = str(row[sheet_mgr.DEDUPE_COL["notes"]]) if row[sheet_mgr.DEDUPE_COL["notes"]] is not None else ""
-            lane = "INBOX_TRASH" if "Lane: INBOX_TRASH" in notes else "ACTIVE"
-            semantic_topic_hint = semantic_hints.get(file_id, "")
+                notes = str(row[sheet_mgr.DEDUPE_COL["notes"]]) if row[sheet_mgr.DEDUPE_COL["notes"]] is not None else ""
+                lane = "INBOX_TRASH" if "Lane: INBOX_TRASH" in notes else "ACTIVE"
+                semantic_topic_hint = semantic_hints.get(file_id, "")
 
-            folder_rule, folder_rule_reason, target_name, target_id, target_path = sorter.determine_target({
-                "name": name,
-                "mime_type": mime_type,
-                "status": status,
-                "path": current_path,
-                "lane": lane,
-                "current_parent_id": current_parent_id,
-                "semantic_topic_hint": semantic_topic_hint,
-            })
+                folder_rule, folder_rule_reason, target_name, target_id, target_path = sorter.determine_target({
+                    "name": name,
+                    "mime_type": mime_type,
+                    "status": status,
+                    "path": current_path,
+                    "lane": lane,
+                    "current_parent_id": current_parent_id,
+                    "semantic_topic_hint": semantic_topic_hint,
+                })
 
-            if not target_id:
-                errors += 1
-                folder_rule_reason = f"FEHLER: Zielordner-ID nicht gefunden ({target_name})"
+                if not target_id:
+                    errors += 1
+                    folder_rule_reason = f"FEHLER: Zielordner-ID nicht gefunden ({target_name})"
 
-            action_mode = "SAFE"
-            if folder_rule == "01_inbox_trash":
-                action_mode = "SWEEP_TRASH"
+                action_mode = "SAFE"
+                if folder_rule == "01_inbox_trash":
+                    action_mode = "SWEEP_TRASH"
 
-            suggestions.append([
-                current_run_id,
-                file_id,
-                name,
-                mime_type,
-                current_path,
-                current_parent_id,
-                folder_rule, folder_rule_reason, target_name, target_id, target_path, action_mode, "PENDING"
-            ])
-            processed += 1
+                suggestions.append([
+                    current_run_id,
+                    file_id,
+                    name,
+                    mime_type,
+                    current_path,
+                    current_parent_id,
+                    folder_rule, folder_rule_reason, target_name, target_id, target_path, action_mode, "PENDING"
+                ])
+                processed += 1
 
-        if suggestions:
-            sheet_mgr.append_rows("Sorting_Suggestions", suggestions)
-            suggestions = []
+            if suggestions:
+                sheet_mgr.append_rows("Sorting_Suggestions", suggestions)
+                suggestions = []
 
-    state.log_run("SAFE_SORT", "SUCCESS", processed, errors)
-    log.info("Safe Sort beendet", extra={"processed": processed})
+        state.log_run("SAFE_SORT", "SUCCESS", processed, errors)
+        log.info("Safe Sort beendet", extra={"processed": processed})
+
+    finally:
+        state.release_job_lock("safe_sort")
 
 
 if __name__ == "__main__":

--- a/bummdidumm_os_v5_final_release/personal_brain/runtime.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/runtime.py
@@ -25,6 +25,27 @@ class PersonalBrainRuntime:
         purged_file_ids: set[str] = {
             fid for fid, status in exclusions.items() if status == "PURGED"
         }
+
+        # Auto-exclude physically removed/unavailable sources so parsers are not
+        # called on inaccessible content.  Existing brain records are preserved
+        # (EXCLUDED semantics).  To fully remove brain records, set PURGED in
+        # Knowledge_Exclusions.  Explicit Knowledge_Exclusions entries always win.
+        _REMOVAL_CHANGE_TYPES = frozenset(
+            {"DELETED", "TRASHED", "REMOVED_OR_NO_ACCESS", "MOVED_OUT_OF_SCOPE"}
+        )
+        _dynamic_exclusions: dict[str, str] = {}
+        for _item in sources:
+            _fid = _item.get("file_id", "")
+            if (
+                _fid
+                and _item.get("change_type") in _REMOVAL_CHANGE_TYPES
+                and _fid not in exclusions
+            ):
+                _dynamic_exclusions[_fid] = "EXCLUDED"
+        effective_exclusions: dict[str, str] = (
+            {**_dynamic_exclusions, **exclusions} if _dynamic_exclusions else exclusions
+        )
+
         source_rows: dict[str, dict] = {}
         record_rows: dict[str, dict] = {}
         entity_rows: dict[str, dict] = {}
@@ -33,7 +54,7 @@ class PersonalBrainRuntime:
         for item in sources:
             file_id = item.get("file_id", "")
             parent_file_id = item.get("bundle_id", "")
-            knowledge_status = exclusions.get(file_id, exclusions.get(parent_file_id, "ACTIVE"))
+            knowledge_status = effective_exclusions.get(file_id, effective_exclusions.get(parent_file_id, "ACTIVE"))
             item["knowledge_status"] = knowledge_status
 
             if knowledge_status in ["EXCLUDED", "PURGED"]:

--- a/bummdidumm_os_v5_final_release/personal_brain/writers.py
+++ b/bummdidumm_os_v5_final_release/personal_brain/writers.py
@@ -116,15 +116,24 @@ class JsonlWriter:
     # Write helpers
     # ------------------------------------------------------------------
 
-    def _write_jsonl(self, path: Path, rows: list[dict], key: str, purged_file_ids: set | None = None) -> None:
+    def _write_jsonl(
+        self,
+        path: Path,
+        rows: list[dict],
+        key: str,
+        purged_file_ids: set | None = None,
+        purged_source_ids: set | None = None,
+    ) -> None:
         """Streaming-Merge-Write: new rows overwrite existing rows by stable ID.
 
         Existing rows absent from `rows` are streamed directly to the temp file
         without being buffered in RAM. Only the incoming `rows` (O(m)) are held
         in memory, avoiding the previous O(n) full-load for large indices.
 
-        purged_file_ids: if provided, existing rows whose ``file_id`` field is in
-        this set are tombstone-deleted (BUG-4 fix for PURGED sources persisting).
+        purged_file_ids: existing rows whose ``file_id`` field is in this set are
+        tombstone-deleted (sources / records).
+        purged_source_ids: existing rows whose ``source_ids`` list is a subset of
+        this set are tombstone-deleted (relations).
         """
         path.parent.mkdir(parents=True, exist_ok=True)
         new_lookup = {row[key]: row for row in rows}
@@ -151,6 +160,10 @@ class JsonlWriter:
                             if k not in new_lookup:
                                 if purged_file_ids and row.get("file_id") in purged_file_ids:
                                     continue  # BUG-4 fix: tombstone-delete PURGED entry
+                                if purged_source_ids:
+                                    row_sids = row.get("source_ids", [])
+                                    if row_sids and all(sid in purged_source_ids for sid in row_sids):
+                                        continue  # tombstone: all contributing sources are purged
                                 out.write(stripped + "\n")
                         except Exception as e:
                             _log.warning(
@@ -230,6 +243,19 @@ class JsonlWriter:
         purged_file_ids: set | None = None,
     ) -> None:
         pf = purged_file_ids or set()
+
+        # Build source_id → file_id mapping from the EXISTING on-disk source registry
+        # BEFORE tombstoning it, so we know which source_ids belong to purged files.
+        # This allows entity / relation tombstoning keyed on source_ids rather than file_id.
+        purged_source_ids: set[str] = set()
+        if pf:
+            src_reg_path = self.published / "00_source_registry.jsonl"
+            for _existing_src in self._stream_jsonl(src_reg_path):
+                if _existing_src.get("file_id") in pf:
+                    _sid = _existing_src.get("source_id", "")
+                    if _sid:
+                        purged_source_ids.add(_sid)
+
         self._write_jsonl(self.published / "00_source_registry.jsonl", sources, "source_id", purged_file_ids=pf)
         self._write_jsonl(self.published / "01_record_index.jsonl", records, "record_id", purged_file_ids=pf)
 
@@ -257,6 +283,11 @@ class JsonlWriter:
                                          if not ek.startswith("_") or ek == "_counts_by_source"}
                                 out.write(json.dumps(clean, ensure_ascii=False) + "\n")
                             else:
+                                # Tombstone entity if ALL its source_ids map to purged files.
+                                if purged_source_ids:
+                                    ent_sids = existing_ent.get("source_ids", [])
+                                    if ent_sids and all(sid in purged_source_ids for sid in ent_sids):
+                                        continue  # tombstone: no surviving sources
                                 out.write(stripped + "\n")
                         except Exception as e:
                             _log.warning(
@@ -269,13 +300,18 @@ class JsonlWriter:
                 out.write(json.dumps(clean, ensure_ascii=False) + "\n")
         tmp_entity_path.replace(entity_path)
 
-        self._write_jsonl(self.published / "03_relation_index.jsonl", relations, "relation_id")
-        self._write_topic_hints(records)
+        self._write_jsonl(
+            self.published / "03_relation_index.jsonl", relations, "relation_id",
+            purged_source_ids=purged_source_ids,
+        )
+        self._write_topic_hints(records, purged_file_ids=pf)
 
-    def _write_topic_hints(self, records: list[dict]) -> None:
+    def _write_topic_hints(self, records: list[dict], purged_file_ids: set | None = None) -> None:
         """Maintain a compact file_id→topic lookup used by main_safe_sort.py.
 
         Merges with existing hints so partial re-runs don't erase previous data.
+        Entries for purged_file_ids are removed so stale topics don't drive
+        sorting decisions after a file is purged.
         The resulting file_topics.json is orders of magnitude smaller than the
         full record index, making Safe Sort startup much faster.
         """
@@ -286,6 +322,9 @@ class JsonlWriter:
                 existing = json.loads(hint_path.read_text(encoding="utf-8"))
             except Exception as e:
                 _log.warning("Could not load existing topic hints", extra={"error": str(e)})
+        if purged_file_ids:
+            for _fid in purged_file_ids:
+                existing.pop(_fid, None)
         for rec in records:
             fid = rec.get("file_id")
             topics = rec.get("topics", [])
@@ -312,6 +351,19 @@ class JsonlWriter:
             with tmp_path.open("w", encoding="utf-8") as f:
                 json.dump(payload, f, ensure_ascii=False, indent=2)
             tmp_path.replace(target_path)
+        # Delete stale day files whose records were all tombstoned.
+        # build_daily_memory() returns no entry for days with zero surviving records,
+        # so any on-disk file absent from `daily` must be removed explicitly.
+        rebuilt_days = set(daily.keys())
+        if self.daily_dir.exists():
+            for _stale in self.daily_dir.glob("*.json"):
+                if _stale.stem not in rebuilt_days:
+                    try:
+                        _stale.unlink()
+                        _log.info("Deleted stale daily memory file", extra={"day": _stale.stem})
+                    except OSError as _e:
+                        _log.warning("Failed to delete stale daily memory file",
+                                     extra={"day": _stale.stem, "error": str(_e)})
         return daily
 
     def write_weekly_memory(self, _records: list[dict]) -> dict[str, dict]:
@@ -337,6 +389,17 @@ class JsonlWriter:
             with tmp.open("w", encoding="utf-8") as wf:
                 _json.dump(payload, wf, ensure_ascii=False, indent=2)
             tmp.replace(target)
+        # Delete stale weekly files whose days were all removed.
+        rebuilt_weeks = set(weekly.keys())
+        if weekly_dir.exists():
+            for _stale in weekly_dir.glob("*.json"):
+                if _stale.stem not in rebuilt_weeks:
+                    try:
+                        _stale.unlink()
+                        _log.info("Deleted stale weekly memory file", extra={"week": _stale.stem})
+                    except OSError as _e:
+                        _log.warning("Failed to delete stale weekly memory file",
+                                     extra={"week": _stale.stem, "error": str(_e)})
         return weekly
 
     def write_search_views(self, _records: list[dict]) -> dict[str, list[dict]]:

--- a/bummdidumm_os_v5_final_release/release_audit.py
+++ b/bummdidumm_os_v5_final_release/release_audit.py
@@ -106,6 +106,61 @@ def run_audit() -> bool:
     if "compact_hash_index()" not in p1 or "compact_reports()" not in p1:
         errors.append("Compaction ist nicht im Hauptpfad von Pass 1 verdrahtet")
 
+    # -----------------------------------------------------------------------
+    # Hardening checks (lifecycle + parallelism fixes)
+    # -----------------------------------------------------------------------
+    w = _read(ROOT / "personal_brain" / "writers.py")
+    rt = _read(ROOT / "personal_brain" / "runtime.py")
+    sh_state = _read(ROOT / "shared" / "state_helpers.py")
+    ar = _read(ROOT / "main_apply_renames.py")
+
+    # Gap-C: entity merge loop must have purged_source_ids guard
+    if "purged_source_ids" not in w:
+        errors.append("Gap-C fehlt: entity loop in writers.py hat keinen purged_source_ids Guard")
+    if "all(sid in purged_source_ids" not in w:
+        errors.append("Gap-C fehlt: entity tombstone nutzt kein all(sid in purged_source_ids)")
+
+    # Gap-D: relation writer must receive purged_source_ids
+    if "03_relation_index.jsonl" in w and "purged_source_ids=purged_source_ids" not in w:
+        errors.append("Gap-D fehlt: relation _write_jsonl hat kein purged_source_ids Argument")
+
+    # Gap-E: topic hints must filter purged file_ids
+    if "_write_topic_hints" in w:
+        hints_tail = w.split("_write_topic_hints")[1][:300]
+        if "purged_file_ids" not in hints_tail:
+            errors.append("Gap-E fehlt: _write_topic_hints filtert keine purged_file_ids")
+
+    # Gap-F: write_daily_memory must delete stale day files
+    if "unlink" not in w or "rebuilt_days" not in w:
+        errors.append("Gap-F fehlt: write_daily_memory löscht keine veralteten Tagesdateien")
+
+    # Gap-A: Pass 2 must include MOVED_OUT_OF_SCOPE in valid_statuses
+    if "MOVED_OUT_OF_SCOPE" not in p2:
+        errors.append("Gap-A fehlt: MOVED_OUT_OF_SCOPE nicht in main_pass2.py valid_statuses")
+
+    # Gap-B: runtime.py must auto-exclude removal events
+    if "_REMOVAL_CHANGE_TYPES" not in rt:
+        errors.append("Gap-B fehlt: runtime.py _REMOVAL_CHANGE_TYPES fehlt (auto-exclude logic)")
+    if "effective_exclusions" not in rt:
+        errors.append("Gap-B fehlt: runtime.py nutzt keine effective_exclusions")
+
+    # Gap-G: state_helpers.py must expose job lock helpers
+    if "acquire_job_lock" not in sh_state:
+        errors.append("Gap-G fehlt: acquire_job_lock fehlt in state_helpers.py")
+    if "release_job_lock" not in sh_state:
+        errors.append("Gap-G fehlt: release_job_lock fehlt in state_helpers.py")
+
+    # Gap-G: all downstream scripts must wire the job lock
+    for job_script, job_label in [
+        (ss, "main_safe_sort.py"),
+        (aps, "main_apply_sort.py"),
+        (ar, "main_apply_renames.py"),
+    ]:
+        if "acquire_job_lock" not in job_script:
+            errors.append(f"Gap-G fehlt: {job_label} ruft acquire_job_lock nicht auf")
+        if "release_job_lock" not in job_script:
+            errors.append(f"Gap-G fehlt: {job_label} ruft release_job_lock nicht auf")
+
     summary = {"result": "PASS" if not errors else "FAIL", "errors": errors}
     (ROOT / "release_audit.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     (ROOT / "SELF_AUDIT.md").write_text("# Self Audit\n\n" + ("PASS ✅" if not errors else "FAIL ❌") + ("\n\n" + "\n".join(f"- {e}" for e in errors) if errors else "") + "\n", encoding="utf-8")

--- a/bummdidumm_os_v5_final_release/shared/state_helpers.py
+++ b/bummdidumm_os_v5_final_release/shared/state_helpers.py
@@ -60,6 +60,68 @@ class StateTracker:
             _log.error("State flush fehlgeschlagen", extra={"error": str(e)})
             raise e
 
+    # ------------------------------------------------------------------
+    # Job-level locking for downstream jobs (safe_sort, apply_sort,
+    # apply_renames).  Simpler than the Pass-1 lease — no heartbeat
+    # required for short-lived jobs.
+    # ------------------------------------------------------------------
+
+    def acquire_job_lock(self, job_name: str, timeout_sec: int = 600) -> bool:
+        """Acquire a short-lived job-level lock stored in the State sheet.
+
+        Returns True when the lock is successfully acquired.  Returns False if
+        another instance holds a non-stale lock for the same job.
+
+        State keys used:
+          {job_name}_lock_owner  — owner_id of the lock holder
+          {job_name}_lock_at     — ISO-UTC timestamp of acquisition
+
+        A lock is stale when its age exceeds ``timeout_sec`` and may be
+        taken over by any new caller.
+        """
+        owner_key = f"{job_name}_lock_owner"
+        at_key = f"{job_name}_lock_at"
+
+        self.reload_state()
+        existing_owner = self.get_val(owner_key)
+        lock_at_str = self.get_val(at_key)
+
+        if existing_owner and existing_owner != self.owner_id:
+            stale = False
+            if lock_at_str:
+                try:
+                    lock_t = datetime.fromisoformat(lock_at_str)
+                    diff = (datetime.now(timezone.utc) - lock_t).total_seconds()
+                    stale = diff >= timeout_sec
+                except (ValueError, TypeError):
+                    stale = True  # unreadable timestamp → treat as stale
+            if not stale:
+                _log.warning(
+                    "Job lock held by another instance — aborting",
+                    extra={"job": job_name, "holder": existing_owner, "lock_at": lock_at_str},
+                )
+                return False
+
+        self.set_val(owner_key, self.owner_id)
+        self.set_val(at_key, datetime.now(timezone.utc).isoformat())
+        self.flush_state()
+        return True
+
+    def release_job_lock(self, job_name: str) -> None:
+        """Release a job-level lock if this instance still owns it.
+
+        Does nothing when another instance has already taken over the lock
+        (e.g. after a timeout), preventing accidental invalidation of an
+        active successor's lock.
+        """
+        owner_key = f"{job_name}_lock_owner"
+        at_key = f"{job_name}_lock_at"
+        self.reload_state()
+        if self.get_val(owner_key) == self.owner_id:
+            self.set_val(owner_key, "")
+            self.set_val(at_key, "")
+            self.flush_state()
+
     def compact_hash_index(self):
         COMPACT_THRESHOLD = int(os.environ.get("HASH_INDEX_COMPACT_THRESHOLD", "50000"))
         known = self.load_known_hashes()

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_job_locks.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_job_locks.py
@@ -1,0 +1,198 @@
+"""Tests for job-level lock helpers in StateTracker.
+
+Gap-G: downstream jobs (safe_sort, apply_sort, apply_renames) must use
+acquire_job_lock / release_job_lock to prevent concurrent corruption.
+
+Uses a shared in-memory state store (similar to test_parallel_run_guard.py)
+to exercise the lock logic without real Sheets API calls.
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone, timedelta
+
+from shared.state_helpers import StateTracker
+
+
+class SharedStateStore:
+    """Minimal shared state backend for StateTracker tests."""
+    def __init__(self, initial: dict | None = None):
+        self.data: dict[str, str] = dict(initial or {})
+
+
+def _make_tracker(store: SharedStateStore, owner_id: str) -> StateTracker:
+    """Build a StateTracker backed by a shared in-memory store."""
+    tracker = StateTracker.__new__(StateTracker)
+    tracker.owner_id = owner_id
+    tracker.run_id = f"run_{owner_id}"
+    tracker._state_cache = dict(store.data)
+    tracker._known_hashes = None
+    tracker._dirty = False
+
+    def _flush():
+        if tracker._dirty:
+            store.data.clear()
+            store.data.update(tracker._state_cache)
+            tracker._dirty = False
+
+    def _reload():
+        tracker._state_cache = dict(store.data)
+
+    def _set_val(key, val):
+        tracker._state_cache[key] = str(val) if val is not None else ""
+        tracker._dirty = True
+
+    def _get_val(key):
+        return tracker._state_cache.get(key)
+
+    tracker.flush_state = _flush
+    tracker.reload_state = _reload
+    tracker.set_val = _set_val
+    tracker.get_val = _get_val
+    return tracker
+
+
+class TestAcquireJobLock(unittest.TestCase):
+
+    def test_first_instance_acquires_lock(self):
+        store = SharedStateStore()
+        t = _make_tracker(store, "owner_a")
+        result = t.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertTrue(result, "First instance must acquire the lock")
+        self.assertEqual(store.data.get("safe_sort_lock_owner"), "owner_a")
+
+    def test_second_instance_blocked_by_fresh_lock(self):
+        store = SharedStateStore()
+        t_a = _make_tracker(store, "owner_a")
+        t_b = _make_tracker(store, "owner_b")
+
+        t_a.acquire_job_lock("safe_sort", timeout_sec=600)
+        result_b = t_b.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertFalse(result_b, "Second instance must be blocked when lock is fresh")
+        # Lock owner must remain owner_a
+        self.assertEqual(store.data.get("safe_sort_lock_owner"), "owner_a")
+
+    def test_stale_lock_can_be_taken_over(self):
+        stale_at = (datetime.now(timezone.utc) - timedelta(seconds=700)).isoformat()
+        store = SharedStateStore({
+            "safe_sort_lock_owner": "owner_old",
+            "safe_sort_lock_at": stale_at,
+        })
+        t_new = _make_tracker(store, "owner_new")
+        result = t_new.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertTrue(result, "New instance must be able to take over a stale lock")
+        self.assertEqual(store.data.get("safe_sort_lock_owner"), "owner_new")
+
+    def test_lock_not_taken_over_before_timeout(self):
+        recent_at = (datetime.now(timezone.utc) - timedelta(seconds=100)).isoformat()
+        store = SharedStateStore({
+            "safe_sort_lock_owner": "owner_running",
+            "safe_sort_lock_at": recent_at,
+        })
+        t_other = _make_tracker(store, "owner_other")
+        result = t_other.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertFalse(result, "Lock must NOT be taken over before timeout expires")
+
+    def test_same_owner_can_re_acquire(self):
+        store = SharedStateStore()
+        t = _make_tracker(store, "owner_self")
+        t.acquire_job_lock("safe_sort", timeout_sec=600)
+        # Same owner tries again (e.g. restart with same owner_id) — must succeed.
+        result = t.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertTrue(result, "Same owner must be able to re-acquire its own lock")
+
+    def test_unreadable_lock_timestamp_treated_as_stale(self):
+        store = SharedStateStore({
+            "safe_sort_lock_owner": "owner_broken",
+            "safe_sort_lock_at": "not-a-timestamp",
+        })
+        t_new = _make_tracker(store, "owner_new")
+        result = t_new.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertTrue(result, "Unreadable timestamp must be treated as stale → lock takeover")
+
+    def test_multiple_jobs_have_independent_locks(self):
+        """Locks for different job names must not interfere."""
+        store = SharedStateStore()
+        t = _make_tracker(store, "owner_a")
+
+        r1 = t.acquire_job_lock("safe_sort", timeout_sec=600)
+        r2 = t.acquire_job_lock("apply_sort", timeout_sec=600)
+        r3 = t.acquire_job_lock("apply_renames", timeout_sec=600)
+        self.assertTrue(r1)
+        self.assertTrue(r2)
+        self.assertTrue(r3)
+        self.assertEqual(store.data.get("safe_sort_lock_owner"), "owner_a")
+        self.assertEqual(store.data.get("apply_sort_lock_owner"), "owner_a")
+        self.assertEqual(store.data.get("apply_renames_lock_owner"), "owner_a")
+
+
+class TestReleaseJobLock(unittest.TestCase):
+
+    def test_release_clears_own_lock(self):
+        store = SharedStateStore()
+        t = _make_tracker(store, "owner_c")
+        t.acquire_job_lock("apply_sort", timeout_sec=600)
+        self.assertEqual(store.data.get("apply_sort_lock_owner"), "owner_c")
+
+        t.release_job_lock("apply_sort")
+        self.assertEqual(store.data.get("apply_sort_lock_owner", ""), "",
+                         "Lock owner must be cleared after release")
+        self.assertEqual(store.data.get("apply_sort_lock_at", ""), "")
+
+    def test_release_does_not_clear_foreign_lock(self):
+        store = SharedStateStore({
+            "apply_sort_lock_owner": "owner_foreign",
+            "apply_sort_lock_at": datetime.now(timezone.utc).isoformat(),
+        })
+        t_local = _make_tracker(store, "owner_local")
+        t_local.release_job_lock("apply_sort")
+        # Foreign lock must remain intact
+        self.assertEqual(store.data.get("apply_sort_lock_owner"), "owner_foreign",
+                         "release must not clear a lock held by a different instance")
+
+    def test_lock_can_be_acquired_after_release(self):
+        store = SharedStateStore()
+        t_a = _make_tracker(store, "owner_a")
+        t_b = _make_tracker(store, "owner_b")
+
+        t_a.acquire_job_lock("safe_sort", timeout_sec=600)
+        t_a.release_job_lock("safe_sort")
+
+        result_b = t_b.acquire_job_lock("safe_sort", timeout_sec=600)
+        self.assertTrue(result_b, "Lock must be acquirable after the previous holder releases it")
+        self.assertEqual(store.data.get("safe_sort_lock_owner"), "owner_b")
+
+
+class TestJobLockWiringInScripts(unittest.TestCase):
+    """Structural regression: downstream scripts must call acquire/release."""
+
+    def _read(self, rel_path: str) -> str:
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        p = root / rel_path
+        return p.read_text(encoding="utf-8") if p.is_file() else ""
+
+    def test_safe_sort_wires_acquire(self):
+        code = self._read("main_safe_sort.py")
+        self.assertIn("acquire_job_lock", code,
+                      "main_safe_sort.py must call acquire_job_lock")
+        self.assertIn("release_job_lock", code,
+                      "main_safe_sort.py must call release_job_lock")
+
+    def test_apply_sort_wires_acquire(self):
+        code = self._read("main_apply_sort.py")
+        self.assertIn("acquire_job_lock", code,
+                      "main_apply_sort.py must call acquire_job_lock")
+        self.assertIn("release_job_lock", code,
+                      "main_apply_sort.py must call release_job_lock")
+
+    def test_apply_renames_wires_acquire(self):
+        code = self._read("main_apply_renames.py")
+        self.assertIn("acquire_job_lock", code,
+                      "main_apply_renames.py must call acquire_job_lock")
+        self.assertIn("release_job_lock", code,
+                      "main_apply_renames.py must call release_job_lock")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_purge_lifecycle.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_purge_lifecycle.py
@@ -1,0 +1,262 @@
+"""Tests for PURGED lifecycle semantics in the Personal Brain writers layer.
+
+Covers: entity tombstoning, relation tombstoning, topic hints cleanup, and
+stale daily/weekly memory file deletion.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from personal_brain.writers import JsonlWriter
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def _write_source_reg(writer: JsonlWriter, sources: list[dict]) -> None:
+    """Helper: write source registry without touching other indexes."""
+    writer._write_jsonl(writer.published / "00_source_registry.jsonl", sources, "source_id")
+
+
+class TestEntityTombstoning(unittest.TestCase):
+    """Gap-C: entities whose ALL source_ids map to purged file_ids must be removed."""
+
+    def test_entity_tombstoned_when_all_sources_purged(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            # Prime the source registry so purged_source_ids can be derived.
+            _write_source_reg(writer, [{"source_id": "src_a", "file_id": "file_a"}])
+
+            # Write an entity whose only source_id is src_a.
+            writer.write_source_record_entity_relation(
+                sources=[],
+                records=[],
+                entities=[{
+                    "entity_id": "ent_alice",
+                    "entity_type": "person",
+                    "canonical_name": "alice",
+                    "source_ids": ["src_a"],
+                }],
+                relations=[],
+            )
+            entities_before = _read_jsonl(writer.published / "02_entity_index.jsonl")
+            self.assertEqual(len(entities_before), 1)
+
+            # Now purge file_a — the entity's only source must be tombstoned.
+            writer.write_source_record_entity_relation(
+                sources=[], records=[], entities=[], relations=[],
+                purged_file_ids={"file_a"},
+            )
+            entities_after = _read_jsonl(writer.published / "02_entity_index.jsonl")
+            entity_ids = [e["entity_id"] for e in entities_after]
+            self.assertNotIn("ent_alice", entity_ids,
+                             "Entity must be tombstoned when all its sources are purged")
+
+    def test_entity_preserved_when_only_some_sources_purged(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            _write_source_reg(writer, [
+                {"source_id": "src_a", "file_id": "file_a"},
+                {"source_id": "src_b", "file_id": "file_b"},
+            ])
+            # Entity references two sources.
+            writer.write_source_record_entity_relation(
+                sources=[],
+                records=[],
+                entities=[{
+                    "entity_id": "ent_bob",
+                    "entity_type": "person",
+                    "canonical_name": "bob",
+                    "source_ids": ["src_a", "src_b"],
+                }],
+                relations=[],
+            )
+            # Purge only file_a — entity still has src_b → must survive.
+            writer.write_source_record_entity_relation(
+                sources=[], records=[], entities=[], relations=[],
+                purged_file_ids={"file_a"},
+            )
+            entities_after = _read_jsonl(writer.published / "02_entity_index.jsonl")
+            entity_ids = [e["entity_id"] for e in entities_after]
+            self.assertIn("ent_bob", entity_ids,
+                          "Entity with surviving sources must NOT be tombstoned")
+
+    def test_entity_with_empty_source_ids_not_tombstoned(self):
+        """Malformed entity (empty source_ids) must stream through safely."""
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            _write_source_reg(writer, [{"source_id": "src_x", "file_id": "file_x"}])
+            writer.write_source_record_entity_relation(
+                sources=[], records=[],
+                entities=[{"entity_id": "ent_orphan", "source_ids": []}],
+                relations=[],
+            )
+            writer.write_source_record_entity_relation(
+                sources=[], records=[], entities=[], relations=[],
+                purged_file_ids={"file_x"},
+            )
+            entities_after = _read_jsonl(writer.published / "02_entity_index.jsonl")
+            self.assertTrue(
+                any(e["entity_id"] == "ent_orphan" for e in entities_after),
+                "Entity with empty source_ids must NOT be silently tombstoned",
+            )
+
+
+class TestRelationTombstoning(unittest.TestCase):
+    """Gap-D: relations whose ALL source_ids map to purged files must be removed."""
+
+    def test_relation_tombstoned_when_all_sources_purged(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            _write_source_reg(writer, [{"source_id": "src_r", "file_id": "file_r"}])
+            writer.write_source_record_entity_relation(
+                sources=[],
+                records=[],
+                entities=[],
+                relations=[{
+                    "relation_id": "rel_1",
+                    "source_ids": ["src_r"],
+                    "predicate": "mentions",
+                }],
+            )
+            rels_before = _read_jsonl(writer.published / "03_relation_index.jsonl")
+            self.assertEqual(len(rels_before), 1)
+
+            writer.write_source_record_entity_relation(
+                sources=[], records=[], entities=[], relations=[],
+                purged_file_ids={"file_r"},
+            )
+            rels_after = _read_jsonl(writer.published / "03_relation_index.jsonl")
+            self.assertEqual(len(rels_after), 0,
+                             "Relation must be tombstoned when its only source is purged")
+
+    def test_relation_preserved_when_only_some_sources_purged(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            _write_source_reg(writer, [
+                {"source_id": "src_p", "file_id": "file_p"},
+                {"source_id": "src_q", "file_id": "file_q"},
+            ])
+            writer.write_source_record_entity_relation(
+                sources=[], records=[], entities=[],
+                relations=[{
+                    "relation_id": "rel_multi",
+                    "source_ids": ["src_p", "src_q"],
+                }],
+            )
+            writer.write_source_record_entity_relation(
+                sources=[], records=[], entities=[], relations=[],
+                purged_file_ids={"file_p"},
+            )
+            rels_after = _read_jsonl(writer.published / "03_relation_index.jsonl")
+            rel_ids = [r["relation_id"] for r in rels_after]
+            self.assertIn("rel_multi", rel_ids,
+                          "Relation with surviving sources must NOT be tombstoned")
+
+
+class TestTopicHintsPurge(unittest.TestCase):
+    """Gap-E: purged file_ids must be removed from file_topics.json."""
+
+    def test_purged_file_id_removed_from_hints(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            hint_path = writer.published / "file_topics.json"
+
+            # Prime hint file with two entries.
+            hint_path.write_text(
+                json.dumps({"keep_file": "finance", "purge_file": "travel"}),
+                encoding="utf-8",
+            )
+
+            writer._write_topic_hints(records=[], purged_file_ids={"purge_file"})
+
+            hints = json.loads(hint_path.read_text(encoding="utf-8"))
+            self.assertIn("keep_file", hints, "Non-purged entry must remain")
+            self.assertNotIn("purge_file", hints, "Purged file_id must be removed")
+
+    def test_no_purge_ids_leaves_hints_intact(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            hint_path = writer.published / "file_topics.json"
+            hint_path.write_text(json.dumps({"f1": "work", "f2": "home"}), encoding="utf-8")
+
+            writer._write_topic_hints(records=[], purged_file_ids=None)
+
+            hints = json.loads(hint_path.read_text(encoding="utf-8"))
+            self.assertEqual(set(hints.keys()), {"f1", "f2"})
+
+
+class TestStaleDailyMemoryCleanup(unittest.TestCase):
+    """Gap-F: day files with zero surviving records must be deleted after a purge."""
+
+    def test_stale_day_file_deleted_when_no_records_remain(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            stale_day = "2020-01-01"
+            stale_path = writer.daily_dir / f"{stale_day}.json"
+            stale_path.write_text(json.dumps({"date": stale_day, "record_count": 1}),
+                                  encoding="utf-8")
+            self.assertTrue(stale_path.exists(), "Stale file must exist before the test")
+
+            # write_daily_memory rebuilds from the (empty) record index.
+            # 01_record_index.jsonl does not exist → zero records → stale file removed.
+            writer.write_daily_memory([])
+
+            self.assertFalse(stale_path.exists(),
+                             "Stale daily memory file must be deleted when no records survive")
+
+    def test_active_day_file_kept(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            # Create a record index so write_daily_memory produces at least one entry.
+            records_path = writer.published / "01_record_index.jsonl"
+            records_path.write_text(
+                json.dumps({
+                    "record_id": "r1", "file_id": "f1",
+                    "event_date": "2025-06-15",
+                    "importance_score": 0.8,
+                    "title": "Test", "summary": "",
+                    "people": [], "places": [], "apps": [],
+                    "record_type": "generic_record",
+                }) + "\n",
+                encoding="utf-8",
+            )
+            writer.write_daily_memory([])
+            day_file = writer.daily_dir / "2025-06-15.json"
+            self.assertTrue(day_file.exists(),
+                            "Day file for a date with records must NOT be deleted")
+
+
+class TestStaleWeeklyMemoryCleanup(unittest.TestCase):
+    """Gap-F: week files with no surviving days must be deleted."""
+
+    def test_stale_week_file_deleted_when_daily_gone(self):
+        with tempfile.TemporaryDirectory() as td:
+            writer = JsonlWriter(Path(td))
+            weekly_dir = writer.published / "04_weekly_memory"
+            weekly_dir.mkdir(parents=True, exist_ok=True)
+            stale_week = "2020-W01"
+            stale_path = weekly_dir / f"{stale_week}.json"
+            stale_path.write_text(json.dumps({"week": stale_week}), encoding="utf-8")
+            self.assertTrue(stale_path.exists())
+
+            # No daily files → weekly rebuild produces empty dict → stale week removed.
+            writer.write_weekly_memory([])
+
+            self.assertFalse(stale_path.exists(),
+                             "Stale weekly memory file must be deleted when its days are gone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_scope_exit_brain.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_scope_exit_brain.py
@@ -1,0 +1,157 @@
+"""Tests for auto-exclusion of scope-exited / deleted sources in the brain runtime.
+
+Gap-A: MOVED_OUT_OF_SCOPE events must not re-index content and must not clear
+existing brain records (EXCLUDED semantics, not PURGED).
+
+Gap-B: DELETED / TRASHED / REMOVED_OR_NO_ACCESS sources are likewise auto-excluded.
+
+The effective_exclusions dict (built dynamically in runtime.py) must give
+explicit Knowledge_Exclusions entries priority over auto-exclusions.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from personal_brain.runtime import PersonalBrainRuntime
+
+
+def _jsonl_file_ids(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    ids = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            row = json.loads(line)
+            fid = row.get("file_id", "")
+            if fid:
+                ids.add(fid)
+    return ids
+
+
+def _minimal_source(file_id: str, change_type: str = "") -> dict:
+    return {
+        "file_id": file_id,
+        "source_path": f"/fake/{file_id}.txt",
+        "source_path_rel": f"{file_id}.txt",
+        "original_filename": f"{file_id}.txt",
+        "mime": "text/plain",
+        "ext": ".txt",
+        "content": {"title": f"{file_id}.txt", "raw_text": "hello world"},
+        "change_type": change_type,
+    }
+
+
+class TestAutoExcludeRemovedSources(unittest.TestCase):
+    """Files with removal change_types must be auto-excluded (brain records preserved)."""
+
+    def _index_and_then_remove(self, change_type: str):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = PersonalBrainRuntime("proj", root)
+            pub = root / "20_index" / "published"
+
+            # Run 1: index the file normally.
+            runtime.process_sources([_minimal_source("file_x")])
+            source_ids_before = _jsonl_file_ids(pub / "00_source_registry.jsonl")
+            self.assertIn("file_x", source_ids_before, "File must be indexed in run 1")
+            record_ids_before = _jsonl_file_ids(pub / "01_record_index.jsonl")
+            # Records may or may not exist depending on parser — we just verify source exists.
+
+            # Run 2: file exits scope / is deleted.
+            removal_source = _minimal_source("file_x", change_type=change_type)
+            runtime.process_sources([removal_source])
+
+            # The source entry must NOT be re-indexed (parser must not be called on
+            # inaccessible content); existing records are preserved (EXCLUDED semantics).
+            # Specifically: the source registry must still contain file_x (preserved),
+            # and no new parser output must have overwritten it with error status.
+            source_ids_after = _jsonl_file_ids(pub / "00_source_registry.jsonl")
+            self.assertIn(
+                "file_x", source_ids_after,
+                f"EXCLUDED source ({change_type}) must preserve existing registry entry",
+            )
+            return pub
+
+    def test_moved_out_of_scope_auto_excluded(self):
+        self._index_and_then_remove("MOVED_OUT_OF_SCOPE")
+
+    def test_deleted_auto_excluded(self):
+        self._index_and_then_remove("DELETED")
+
+    def test_trashed_auto_excluded(self):
+        self._index_and_then_remove("TRASHED")
+
+    def test_removed_or_no_access_auto_excluded(self):
+        self._index_and_then_remove("REMOVED_OR_NO_ACCESS")
+
+    def test_removal_source_does_not_call_parser(self):
+        """A removal source must NOT produce new records (parser must be bypassed)."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = PersonalBrainRuntime("proj", root)
+            pub = root / "20_index" / "published"
+
+            # Run 1: index a file that produces at least one source entry.
+            runtime.process_sources([_minimal_source("file_y")])
+            sources_run1 = []
+            src_path = pub / "00_source_registry.jsonl"
+            if src_path.exists():
+                for line in src_path.read_text(encoding="utf-8").splitlines():
+                    if line.strip():
+                        sources_run1.append(json.loads(line))
+            self.assertTrue(any(s.get("file_id") == "file_y" for s in sources_run1))
+
+            # Run 2: deletion event — same file_id, change_type=DELETED.
+            runtime.process_sources([_minimal_source("file_y", change_type="DELETED")])
+
+            # The scanned_at timestamp of the source must NOT be updated
+            # (parser was not called → entry unchanged from run 1).
+            sources_run2 = []
+            if src_path.exists():
+                for line in src_path.read_text(encoding="utf-8").splitlines():
+                    if line.strip():
+                        sources_run2.append(json.loads(line))
+
+            entry_run1 = next((s for s in sources_run1 if s.get("file_id") == "file_y"), None)
+            entry_run2 = next((s for s in sources_run2 if s.get("file_id") == "file_y"), None)
+            self.assertIsNotNone(entry_run2, "Source entry must still exist after deletion event")
+            if entry_run1 and entry_run2:
+                self.assertEqual(
+                    entry_run1.get("scanned_at"), entry_run2.get("scanned_at"),
+                    "scanned_at must not change when parser is bypassed for deletion event",
+                )
+
+
+class TestExplicitPurgeOverridesAutoExclude(unittest.TestCase):
+    """An explicit PURGED entry in Knowledge_Exclusions must take priority
+    over the auto-EXCLUDED dynamic rule."""
+
+    def test_purged_overrides_auto_excluded(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = PersonalBrainRuntime("proj", root)
+            pub = root / "20_index" / "published"
+
+            # Run 1: index the file.
+            runtime.process_sources([_minimal_source("file_z")])
+            self.assertIn("file_z", _jsonl_file_ids(pub / "00_source_registry.jsonl"))
+
+            # Run 2: deletion event AND explicit PURGED in exclusions.
+            # The PURGED status must win → source must be tombstoned.
+            runtime.process_sources(
+                [_minimal_source("file_z", change_type="DELETED")],
+                exclusions={"file_z": "PURGED"},
+            )
+            source_ids_after = _jsonl_file_ids(pub / "00_source_registry.jsonl")
+            self.assertNotIn(
+                "file_z", source_ids_after,
+                "Explicit PURGED must tombstone the source even when change_type is DELETED",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Gap-A: Add MOVED_OUT_OF_SCOPE to Pass 2 valid_statuses and Path B handler so
scope-exited files reach the brain runtime as event-only entries.

Gap-B: Auto-exclude DELETED/TRASHED/REMOVED_OR_NO_ACCESS/MOVED_OUT_OF_SCOPE
sources in personal_brain/runtime.py via _REMOVAL_CHANGE_TYPES + effective_exclusions;
explicit Knowledge_Exclusions always take priority.

Gap-C: Entity merge loop in writers.py checks purged_source_ids — tombstones
entities only when ALL source_ids belong to purged files.

Gap-D: Relation _write_jsonl receives purged_source_ids so relations with no
surviving sources are tombstoned.

Gap-E: _write_topic_hints accepts purged_file_ids and removes stale entries
from file_topics.json.

Gap-F: write_daily_memory/write_weekly_memory delete stale day/week files
whose records were all tombstoned (tracked via rebuilt_days set).

Gap-G: acquire_job_lock / release_job_lock added to StateTracker; all three
downstream jobs (safe_sort, apply_sort, apply_renames) wire the lock with
per-job timeout env vars and try/finally release.

Tests: 29 new smoke tests (test_purge_lifecycle, test_scope_exit_brain,
test_job_locks) — all passing. Release audit: PASS.

https://claude.ai/code/session_014sMEvKzCYzxSRgxuQZeiR6