### PR TITLE
Consolidate Basel-Radar hardening: Sheets backoff fix, audit/test/doc consistency

### DIFF
--- a/.github/workflows/personal-brain-gates.yml
+++ b/.github/workflows/personal-brain-gates.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
       - name: Validate deploy.sh shell syntax
         run: bash -n bummdidumm_os_v5_final_release/deploy.sh
       - name: Shellcheck deploy.sh

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Die Tests laufen vollständig lokal mit Mocks — kein Google-Account, kein Shee
 | `BRAIN_INDEX_BUCKET` | GCS-Bucket-Name für den Brain-Index (FUSE-Mount via `deploy.sh`) |
 | `ARCHIVE_FOLDER_ID` | Drive-Ordner-ID für archivierte Duplikate |
 | `INDEX_FOLDER_ID` | Drive-Ordner-ID für Index-Ausgaben |
-| `GEMINI_API_KEY` | Gemini-API-Key für OCR — **wird in Cloud Run via Google Secret Manager übergeben** (nicht als Env-Variable setzen; siehe QUICKSTART.md §1.5) |
+| `GEMINI_API_KEY` | Gemini-API-Key für OCR — **wird in Cloud Run via Google Secret Manager übergeben** (nicht als Env-Variable setzen; siehe QUICKSTART.md §1.4) |
 
 **Optional:**
 | Variable | Default | Zweck |

--- a/bummdidumm_os_v5_final_release/OPERATING_MODEL.md
+++ b/bummdidumm_os_v5_final_release/OPERATING_MODEL.md
@@ -6,3 +6,14 @@
 2. Pass 2 schreibt Delta JSONL und ruft anschließend die Parser-Registry-Runtime auf.
 3. Runtime erzeugt deterministische IDs (`source_id`, `record_id`, `entity_id`, `relation_id`) aus stabilen Hashes.
 4. Parserfehler sind isoliert je Quelle (Registry-Fallback auf Generic Parser).
+
+## Bekannte RAM-Grenze: records_to_index in Pass 2
+
+Pass 2 liest die `Dedupe_Report`-Zeilen chunk-weise (JSONL-Schreibpfad), hält aber
+`records_to_index` als vollständige In-Memory-Liste für den `PersonalBrainRuntime`-Aufruf.
+Bei mehr als 50.000 Einträgen loggt Pass 2 eine Warnung (`RAM-Druck möglich`).
+
+**Empfehlung:** OCR-Budget via `OCR_BUDGET_PER_RUN` und `SKIP_OVER_MB` begrenzen,
+um die Listengröße pro Run kontrolliert zu halten. Ein vollständiges Streaming des
+`PersonalBrainRuntime`-Aufrufs würde einen Architekturumbau erfordern und ist
+im aktuellen Release bewusst nicht implementiert (Kommentar in `main_pass2.py`).

--- a/bummdidumm_os_v5_final_release/QUICKSTART.md
+++ b/bummdidumm_os_v5_final_release/QUICKSTART.md
@@ -102,18 +102,26 @@ gcloud storage buckets create gs://PROJECT_ID-brain-index \
 gcloud storage buckets add-iam-policy-binding gs://PROJECT_ID-brain-index \
   --member="serviceAccount:${SA_EMAIL}" \
   --role="roles/storage.objectAdmin"
+```
 
-# Mount the bucket in the Cloud Run Job (Pass 2 and Safe Sort)
+`deploy.sh` automatically configures the GCS FUSE volume mount (`/brain_index`) and
+sets `BRAIN_INDEX_ROOT` for both Pass 2 and Safe Sort when you run it in §3 step 6.
+You do **not** need to run `gcloud run jobs update` manually if you use `deploy.sh`.
+
+If you need to update an already-deployed job without re-running `deploy.sh`, use:
+
+```bash
+# Manual override only — not needed when using deploy.sh
 gcloud run jobs update bummdidumm-pass2-ocr-index \
   --add-volume=name=brain-index,type=cloud-storage,bucket=PROJECT_ID-brain-index \
-  --add-volume-mount=volume=brain-index,mount-path=/mnt/brain-index \
-  --update-env-vars=BRAIN_INDEX_ROOT=/mnt/brain-index \
+  --add-volume-mount=volume=brain-index,mount-path=/brain_index \
+  --update-env-vars=BRAIN_INDEX_ROOT=/brain_index \
   --region=europe-west6
 
 gcloud run jobs update bummdidumm-safe-sort \
   --add-volume=name=brain-index,type=cloud-storage,bucket=PROJECT_ID-brain-index \
-  --add-volume-mount=volume=brain-index,mount-path=/mnt/brain-index \
-  --update-env-vars=BRAIN_INDEX_ROOT=/mnt/brain-index \
+  --add-volume-mount=volume=brain-index,mount-path=/brain_index \
+  --update-env-vars=BRAIN_INDEX_ROOT=/brain_index \
   --region=europe-west6
 ```
 
@@ -198,8 +206,8 @@ Follow these steps in order. Each step has a success criterion.
 | 3 | Create Secret Manager secret and grant SA access (section 1.4) | `gcloud secrets versions access latest --secret=gemini-api-key` returns the key |
 | 4 | Share Drive folders and Control Sheet with the SA email | SA can list the target folder via Drive API |
 | 5 | Create brain-index bucket and grant access (section 1.5) | `gcloud storage ls gs://PROJECT_ID-brain-index` succeeds from SA |
-| 6 | Run `deploy.sh` with all env vars set (no `GEMINI_API_KEY` export needed) | All five `gcloud run jobs deploy` commands exit 0 |
-| 7 | Add Cloud Storage FUSE volume mounts (section 1.5) | `gcloud run jobs describe bummdidumm-pass2-ocr-index` shows the volume |
+| 6 | Run `deploy.sh` with all env vars set (no `GEMINI_API_KEY` export needed) | All five `gcloud run jobs deploy` commands exit 0; `gcloud run jobs describe bummdidumm-pass2-ocr-index` shows the `/brain_index` volume mount (deploy.sh sets this automatically) |
+| 7 | _(Handled by deploy.sh above)_ Volume mounts for Pass 2 and Safe Sort are included in `deploy.sh`. Only use the manual `gcloud run jobs update` commands from section 1.5 if updating an existing job without re-running `deploy.sh`. | No separate action required when using `deploy.sh` |
 | 8 | Execute Pass 1 manually: `gcloud run jobs execute bummdidumm-pass1-delta-dedupe --region europe-west6` | Job status becomes SUCCEEDED; Control Sheet rows appear in `Dedupe_Report` |
 | 9 | Execute Pass 2 manually: `gcloud run jobs execute bummdidumm-pass2-ocr-index --region europe-west6` | Job status becomes SUCCEEDED; `CURRENT_personal_brain_stats.json` written to `BRAIN_INDEX_ROOT` |
 | 10 | Run tests locally against the deployed index | `pytest bummdidumm_os_v5_final_release/tests/ -q` passes |

--- a/bummdidumm_os_v5_final_release/build_release.sh
+++ b/bummdidumm_os_v5_final_release/build_release.sh
@@ -4,4 +4,14 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 python3 bummdidumm_os_v5_final_release/release_audit.py
 rm -f bummdidumm_os_v5_final_release.zip
-zip -r bummdidumm_os_v5_final_release.zip bummdidumm_os_v5_final_release -x "*/__pycache__/*" -x "*.pyc" -x "archive/*"
+zip -r bummdidumm_os_v5_final_release.zip bummdidumm_os_v5_final_release \
+  -x "*/__pycache__/*" \
+  -x "*.pyc" \
+  -x "archive/*" \
+  -x "*/.artifacts/*" \
+  -x "*/brain_index/*" \
+  -x "*/.pytest_cache/*" \
+  -x "*/.mypy_cache/*" \
+  -x "*/.ruff_cache/*" \
+  -x "*.log" \
+  -x "*.zip"

--- a/bummdidumm_os_v5_final_release/main_apply_renames.py
+++ b/bummdidumm_os_v5_final_release/main_apply_renames.py
@@ -119,27 +119,26 @@ def run_apply_renames():
                     "values": [[result_val]]
                 })
 
-                # BUG-E fix: use sheet_mgr._execute_with_backoff for Sheets batch writes
-                # so that transient Sheets 403 (rateLimitExceeded/userRateLimitExceeded/
-                # quotaExceeded) is retried — drive_mgr.execute_with_backoff only retries
-                # 429/500/503 and misses Sheets-specific 403 quota errors.
+                # BUG-E fix: batch Sheets writes use sheet_mgr._execute_with_backoff, which
+                # retries 403 rateLimitExceeded/userRateLimitExceeded/quotaExceeded in
+                # addition to 429/500/503 — drive_mgr.execute_with_backoff misses 403 quota.
                 if len(update_requests) >= 50:
                     _batch = update_requests
-                    drive_mgr.execute_with_backoff(
-                        lambda: sheets_service.spreadsheets().values().batchUpdate(
+                    sheet_mgr._execute_with_backoff(
+                        sheets_service.spreadsheets().values().batchUpdate(
                             spreadsheetId=CONTROL_SHEET_ID,
                             body={"valueInputOption": "RAW", "data": _batch}
-                        ).execute()
+                        )
                     )
                     update_requests = []
 
         if update_requests:
             _batch = update_requests
-            drive_mgr.execute_with_backoff(
-                lambda: sheets_service.spreadsheets().values().batchUpdate(
+            sheet_mgr._execute_with_backoff(
+                sheets_service.spreadsheets().values().batchUpdate(
                     spreadsheetId=CONTROL_SHEET_ID,
                     body={"valueInputOption": "RAW", "data": _batch}
-                ).execute()
+                )
             )
 
         state.log_run("RENAME", "SUCCESS", processed, errors)

--- a/bummdidumm_os_v5_final_release/release_audit.py
+++ b/bummdidumm_os_v5_final_release/release_audit.py
@@ -92,8 +92,12 @@ def run_audit() -> bool:
             errors.append(f"Gemini Robustness fehlt: {must}")
 
     deploy = _read(ROOT / "deploy.sh")
-    if ': "${BRAIN_INDEX_ROOT:?' not in deploy:
-        errors.append("deploy.sh: BRAIN_INDEX_ROOT hat kein fail-fast (:? Syntax) — wird bei fehlendem Mount nicht abgebrochen")
+    # BRAIN_INDEX_ROOT is derived from the GCS FUSE mount path inside deploy.sh;
+    # the real external dependency is BRAIN_INDEX_BUCKET and the volume mount config.
+    if ': "${BRAIN_INDEX_BUCKET:?' not in deploy:
+        errors.append("deploy.sh: BRAIN_INDEX_BUCKET hat kein fail-fast (:? Syntax) — persistenter Brain-Index-Bucket nicht gesichert")
+    if "--add-volume" not in deploy or "--add-volume-mount" not in deploy:
+        errors.append("deploy.sh: GCS FUSE Volume Mount fehlt — Pass 2 und Safe Sort benötigen persistenten Brain-Index-Mount")
     if ': "${SA_EMAIL:?' not in deploy:
         errors.append("deploy.sh: SA_EMAIL hat kein fail-fast (silent default)")
     for _line in deploy.splitlines():
@@ -171,6 +175,30 @@ def run_audit() -> bool:
             errors.append(f"Gap-G fehlt: {job_label} ruft acquire_job_lock nicht auf")
         if "release_job_lock" not in job_script:
             errors.append(f"Gap-G fehlt: {job_label} ruft release_job_lock nicht auf")
+
+    # BUG-E: rename batch Sheets writeback must use the Sheets-specific retry path
+    # (_execute_with_backoff retries 403 rateLimitExceeded/quotaExceeded;
+    #  drive_mgr.execute_with_backoff only retries 429/500/503).
+    if "_execute_with_backoff" not in ar:
+        errors.append("main_apply_renames.py: Rename-Batch-Writeback nutzt kein sheet_mgr._execute_with_backoff — 403-Quota-Retry für Sheets fehlt (BUG-E)")
+    import ast as _ast
+    try:
+        _ar_tree = _ast.parse(ar)
+        for _node in _ast.walk(_ar_tree):
+            if not isinstance(_node, _ast.Call):
+                continue
+            _func = _node.func
+            if not (isinstance(_func, _ast.Attribute) and _func.attr == "execute_with_backoff"):
+                continue
+            for _arg in _node.args:
+                _arg_src = _ast.unparse(_arg) if hasattr(_ast, "unparse") else ""
+                if "batchUpdate" in _arg_src:
+                    errors.append(
+                        "main_apply_renames.py: batchUpdate läuft über drive_mgr.execute_with_backoff "
+                        "statt sheet_mgr._execute_with_backoff — 403-Quota-Fehler werden nicht retried (BUG-E)"
+                    )
+    except SyntaxError:
+        errors.append("main_apply_renames.py: Syntaxfehler — AST-Analyse für BUG-E-Check nicht möglich")
 
     if errors:
         print("RESULT: FAIL")

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_apply_jobs_hardening.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_apply_jobs_hardening.py
@@ -2,7 +2,7 @@
 
 Covers:
 - BUG-K: current_phase set to APPLY_SORT_FAILED / APPLY_RENAMES_FAILED on exception
-- BUG-P0: batch flush uses drive_mgr.execute_with_backoff (retries 500/503)
+- BUG-E: batch Sheets flush uses sheet_mgr._execute_with_backoff (retries 403 quota/rate-limit)
 """
 import os
 import sys
@@ -139,17 +139,20 @@ class TestApplyRenamesFailedPhase:
 
 
 # ---------------------------------------------------------------------------
-# BUG-P0: batch flush retries on 500
+# BUG-E fix: batch Sheets writeback must use Sheets-specific retry path
 # ---------------------------------------------------------------------------
 
-class TestApplyRenamesBatchFlushRetries:
+class TestApplyRenamesSheetsRetry:
+    """Regression: rename batch Sheets writeback uses Sheets-specific retry, not Drive retry.
 
-    def test_apply_renames_batch_flush_retries_500(self):
-        """BUG-P0: batch flush via drive_mgr.execute_with_backoff must retry 500 errors.
+    drive_mgr.execute_with_backoff retries 429/500/503 only.
+    sheet_mgr._execute_with_backoff additionally retries 403 rateLimitExceeded /
+    userRateLimitExceeded / quotaExceeded, which are the dominant Sheets quota errors.
+    """
 
-        Verifies that drive_mgr.execute_with_backoff is used for the batch flush
-        (not sheet_mgr._execute_with_backoff which previously did not retry 500/503).
-        """
+    def test_batch_flush_uses_sheets_backoff_not_drive_backoff(self):
+        """Source-level: batchUpdate calls must route via sheet_mgr._execute_with_backoff."""
+        import ast
         from pathlib import Path
 
         for p in [Path("main_apply_renames.py"),
@@ -160,30 +163,70 @@ class TestApplyRenamesBatchFlushRetries:
         else:
             raise FileNotFoundError("main_apply_renames.py not found")
 
-        # The batch flush must use drive_mgr.execute_with_backoff (lambda-based),
-        # NOT sheet_mgr._execute_with_backoff (which received a pre-built request).
-        assert "drive_mgr.execute_with_backoff" in source, (
-            "Batch flush must use drive_mgr.execute_with_backoff so 500/503 errors "
-            "trigger a retry with a freshly-built request (BUG-P0 fix)"
+        assert "_execute_with_backoff" in source, (
+            "Batch Sheets flush must call sheet_mgr._execute_with_backoff "
+            "so that 403 rateLimitExceeded/quotaExceeded is retried"
         )
-        # The lambda pattern ensures a fresh request is built on each retry
-        assert "lambda" in source, (
-            "Batch flush lambda must be present so the Sheets request is rebuilt "
-            "on each retry attempt"
-        )
-        # The old pattern (sheet_mgr._execute_with_backoff with a pre-built request)
-        # must not be used for the batchUpdate calls
-        import ast
+
+        # drive_mgr.execute_with_backoff must NOT wrap any batchUpdate call
         tree = ast.parse(source)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            if isinstance(func, ast.Attribute) and func.attr == "_execute_with_backoff":
-                # Check if any arg contains batchUpdate
-                for arg in node.args:
-                    arg_src = ast.unparse(arg) if hasattr(ast, "unparse") else ""
-                    assert "batchUpdate" not in arg_src, (
-                        "sheet_mgr._execute_with_backoff must NOT be called with a "
-                        "batchUpdate request — use drive_mgr.execute_with_backoff instead"
-                    )
+            if not (isinstance(func, ast.Attribute) and func.attr == "execute_with_backoff"):
+                continue
+            for arg in node.args:
+                arg_src = ast.unparse(arg) if hasattr(ast, "unparse") else ""
+                assert "batchUpdate" not in arg_src, (
+                    f"drive_mgr.execute_with_backoff must NOT wrap a batchUpdate call "
+                    f"(line {node.lineno}) — use sheet_mgr._execute_with_backoff instead "
+                    f"to handle Sheets 403 quota errors"
+                )
+
+    def test_sheets_403_quota_handled_in_batch_flush(self):
+        """Functional: sheet_mgr._execute_with_backoff is called for the Sheets batch flush."""
+        from unittest.mock import MagicMock, patch
+        import main_apply_renames
+
+        credentials = MagicMock()
+        drive_service = MagicMock()
+        sheets_service = MagicMock()
+        sheet_mgr = MagicMock()
+        state = MagicMock()
+        drive_mgr = MagicMock()
+
+        state.get_val.side_effect = lambda k: "run_001" if k == "last_successful_run_id" else ""
+        state.acquire_job_lock.return_value = True
+
+        dedupe_col = {"run_id": 1, "file_id": 2, "name": 3, "suggested_name": 4, "rename_result": 17}
+        sheet_mgr.DEDUPE_COL = dedupe_col
+        sheet_mgr.headers = {"Dedupe_Report": ["h"] * 18}
+
+        # Row: rename pending (live name matches current → rename proceeds)
+        test_row = ["2026-01-01", "run_001", "file_003", "old_name.pdf", "new_name.pdf"] + [""] * 13
+        sheet_mgr.read_rows_chunked_with_row_numbers.return_value = [(2, test_row)]
+
+        # Drive calls: get returns current name, update returns success
+        drive_mgr.execute_with_backoff.side_effect = [
+            {"name": "old_name.pdf"},
+            {"id": "file_003", "name": "new_name.pdf"},
+        ]
+
+        state.set_val.side_effect = lambda k, v: None
+
+        with (
+            patch("main_apply_renames.CONTROL_SHEET_ID", "test_sheet_id"),
+            patch("main_apply_renames.get_user_credentials", return_value=credentials),
+            patch("main_apply_renames.build", side_effect=[drive_service, sheets_service]),
+            patch("shared.drive_helpers.DriveManager", return_value=drive_mgr),
+            patch("main_apply_renames.SheetManager", return_value=sheet_mgr),
+            patch("main_apply_renames.StateTracker", return_value=state),
+            patch("shared.log.get_logger", return_value=MagicMock()),
+        ):
+            main_apply_renames.run_apply_renames()
+
+        assert sheet_mgr._execute_with_backoff.called, (
+            "sheet_mgr._execute_with_backoff must be called for the Sheets batch flush "
+            "— verifies 403 quota/rate-limit errors are retried by the Sheets-specific path"
+        )

--- a/bummdidumm_os_v5_final_release/tests/smoke/test_pass2_ram_guardrail.py
+++ b/bummdidumm_os_v5_final_release/tests/smoke/test_pass2_ram_guardrail.py
@@ -1,0 +1,39 @@
+"""P2 guardrail: main_pass2.py must warn when records_to_index grows very large."""
+from pathlib import Path
+
+
+def _source() -> str:
+    for p in [
+        Path("main_pass2.py"),
+        Path("bummdidumm_os_v5_final_release/main_pass2.py"),
+    ]:
+        if p.exists():
+            return p.read_text(encoding="utf-8")
+    raise FileNotFoundError("main_pass2.py not found")
+
+
+def test_records_to_index_ram_warning_present():
+    """records_to_index accumulates in memory; a warning must fire at the hardcoded threshold."""
+    source = _source()
+    assert "records_to_index" in source, "records_to_index list must be present in main_pass2.py"
+    assert "50_000" in source or "50000" in source, (
+        "RAM-pressure threshold (50 000) must be explicitly stated in main_pass2.py"
+    )
+    assert "RAM" in source, (
+        "RAM-pressure warning must mention RAM so operators can grep for it in logs"
+    )
+
+
+def test_records_to_index_warning_uses_log_warning():
+    """The RAM guardrail must emit a log.warning, not just a print or silent pass."""
+    source = _source()
+    # Verify the warning block is adjacent to the threshold check
+    idx = source.find("50_000")
+    if idx == -1:
+        idx = source.find("50000")
+    assert idx != -1, "50_000 threshold not found"
+    # The warning call should appear within 300 chars of the threshold check
+    window = source[idx: idx + 300]
+    assert "warning" in window.lower(), (
+        "log.warning must be called within the RAM-pressure guard block"
+    )


### PR DESCRIPTION
P0 — Sheets backoff fix (BUG-E):
- main_apply_renames.py: replace drive_mgr.execute_with_backoff(lambda) with
  sheet_mgr._execute_with_backoff(request) for both batchUpdate flush paths.
  drive_mgr only retries 429/500/503; sheet_mgr._execute_with_backoff also
  retries 403 rateLimitExceeded/userRateLimitExceeded/quotaExceeded.
- test_apply_jobs_hardening.py: replace TestApplyRenamesBatchFlushRetries
  (asserted the wrong backoff path) with TestApplyRenamesSheetsRetry — one
  source-level AST check, one functional mock test.
- release_audit.py: (a) replace stale BRAIN_INDEX_ROOT :? check with
  BRAIN_INDEX_BUCKET :? + --add-volume/--add-volume-mount checks (real external
  dependency is the bucket + FUSE mount, not the derived variable); (b) add
  BUG-E AST check verifying rename batch flush uses _execute_with_backoff.

P1 — Deploy-doc, build, CI hardening:
- QUICKSTART.md: fix /mnt/brain-index → /brain_index throughout; note that
  deploy.sh already handles volume mounts (step 7 updated); manual gcloud
  update commands kept as fallback, clearly marked optional.
- README.md: fix wrong cross-reference §1.5 → §1.4 for GEMINI_API_KEY.
- build_release.sh: add zip excludes for .artifacts/, brain_index/,
  .pytest_cache/, .mypy_cache/, .ruff_cache/, *.log, *.zip.
- personal-brain-gates.yml: install shellcheck explicitly before using it
  (ubuntu-latest does not guarantee shellcheck is pre-installed).

P2 — RAM guardrail documentation + test:
- OPERATING_MODEL.md: document records_to_index in-memory accumulation limit
  and operational mitigation (OCR_BUDGET_PER_RUN, SKIP_OVER_MB).
- tests/smoke/test_pass2_ram_guardrail.py: two static tests verifying the
  50_000-threshold warning is present and calls log.warning.

Verified: release_audit.py → RESULT: PASS; pytest 188/188 passed; bash -n deploy.sh clean.

https://claude.ai/code/session_01N4kvynaYBaXhGZ3ka45U9G